### PR TITLE
Fix `os.ReadFile` OOM

### DIFF
--- a/kernel/web/lib/syscall.js
+++ b/kernel/web/lib/syscall.js
@@ -58,12 +58,8 @@ globalThis.api = {
     // only significant signature change
     read(fd, bufsize, offset, length, position) {
       const buf = new Uint8Array(bufsize);
-      return new Promise((ok, err) => globalThis.fs.read(fd, buf, offset, length, position, (e) => {
-        if (e !== null) {
-          err(e);
-        } else {
-          ok(buf);
-        }
+      return new Promise(resolve => globalThis.fs.read(fd, buf, offset, length, position, (err, n) => {
+        resolve({err, buf, n});
       }));
     },
     readdir(path) { 

--- a/kernel/web/lib/wasm.js
+++ b/kernel/web/lib/wasm.js
@@ -132,10 +132,9 @@
         }
 				globalThis.sys.call("fs.read", [fd, buffer.length, offset, length, position])
 					.then(res => {
-						buffer.set(res.value);
-						callback(null, res.value.length);
-					})
-					.catch(err => callback(err));
+						buffer.set(res.value.buf);
+						callback(res.value.err, res.value.n);
+					});
       },
 			readdir(path, callback) {
 				globalThis.sys.call("fs.readdir", [path])


### PR DESCRIPTION
Closes #1
Turns out we weren't handling EOF properly in our `read` syscall implementation. This fix allows allows the EOF to propagate. Go's interprets a `read` return value of `0, nil` to be EOF.