### PR TITLE
fix make dev target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 all: kernel shell
 
-dev:
+dev: all
 	go run ./dev
 
 bundle: local/bin


### PR DESCRIPTION
at first run `make dev` is missing the kernel and shell. The browser shows 404 for those requests.