### PR TITLE
mountablefs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,10 @@ require (
 	github.com/evanw/esbuild v0.19.5
 	github.com/spf13/afero v1.10.0
 	golang.org/x/term v0.13.0
-	tractor.dev/toolkit-go v0.0.0-20231020134529-7767e3b09e40
+	tractor.dev/toolkit-go v0.0.0-20231108030452-f76673e11cd3
 )
 
 require (
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 )
-
-replace tractor.dev/toolkit-go => ../toolkit-go

--- a/go.sum
+++ b/go.sum
@@ -445,3 +445,5 @@ honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+tractor.dev/toolkit-go v0.0.0-20231108030452-f76673e11cd3 h1:RZ6kq7stc3gPEljEhmbgB7uLQd1xRz2JA68a/HA+6p0=
+tractor.dev/toolkit-go v0.0.0-20231108030452-f76673e11cd3/go.mod h1:gteH4mWzJV+Y5zk6/Q6rPuWeOCFHnr55XPTgYEHuzUo=

--- a/internal/mountablefs/mountablefs.go
+++ b/internal/mountablefs/mountablefs.go
@@ -1,0 +1,384 @@
+package mountablefs
+
+import (
+	"errors"
+	"path/filepath"
+	"slices"
+	"strings"
+	"syscall"
+	"time"
+
+	"tractor.dev/toolkit-go/engine/fs"
+	"tractor.dev/toolkit-go/engine/fs/fsutil"
+)
+
+type mountedFSDir struct {
+	fsys       fs.FS
+	mountPoint string
+}
+
+type FS struct {
+	fs.MutableFS
+	mounts []mountedFSDir
+}
+
+func New(fsys fs.MutableFS) *FS {
+	return &FS{MutableFS: fsys, mounts: make([]mountedFSDir, 0, 1)}
+}
+
+func (host *FS) Mount(fsys fs.FS, dirPath string) error {
+	dirPath = cleanPath(dirPath)
+
+	fi, err := fs.Stat(host, dirPath)
+	if err != nil {
+		return err
+	}
+
+	if !fi.IsDir() {
+		return &fs.PathError{Op: "mount", Path: dirPath, Err: fs.ErrInvalid}
+	}
+	if found, _ := host.isPathInMount(dirPath); found {
+		return &fs.PathError{Op: "mount", Path: dirPath, Err: fs.ErrExist}
+	}
+
+	host.mounts = append(host.mounts, mountedFSDir{fsys: fsys, mountPoint: dirPath})
+	return nil
+}
+
+func (host *FS) Unmount(path string) error {
+	path = cleanPath(path)
+	for i, m := range host.mounts {
+		if path == m.mountPoint {
+			host.mounts = remove(host.mounts, i)
+			return nil
+		}
+	}
+
+	return &fs.PathError{Op: "unmount", Path: path, Err: fs.ErrInvalid}
+}
+
+func remove(s []mountedFSDir, i int) []mountedFSDir {
+	s[i] = s[len(s)-1]
+	return s[:len(s)-1]
+}
+
+func (host *FS) isPathInMount(path string) (bool, *mountedFSDir) {
+	for i, m := range host.mounts {
+		if strings.HasPrefix(path, m.mountPoint) {
+			return true, &host.mounts[i]
+		}
+	}
+	return false, nil
+}
+
+func cleanPath(p string) string {
+	return filepath.Clean(strings.TrimLeft(p, "/\\"))
+}
+
+func trimMountPoint(path string, mntPoint string) string {
+	result := strings.TrimPrefix(path, mntPoint)
+	result = strings.TrimPrefix(result, string(filepath.Separator))
+
+	if result == "" {
+		return "."
+	} else {
+		return result
+	}
+}
+
+func (host *FS) Chmod(name string, mode fs.FileMode) error {
+	name = cleanPath(name)
+	var fsys fs.FS
+	prefix := ""
+
+	if found, mount := host.isPathInMount(name); found {
+		fsys = mount.fsys
+		prefix = mount.mountPoint
+	} else {
+		fsys = host.MutableFS
+	}
+
+	chmodableFS, ok := fsys.(interface {
+		Chmod(name string, mode fs.FileMode) error
+	})
+	if !ok {
+		return &fs.PathError{Op: "chmod", Path: name, Err: errors.ErrUnsupported}
+	}
+	return chmodableFS.Chmod(trimMountPoint(name, prefix), mode)
+}
+
+func (host *FS) Chown(name string, uid, gid int) error {
+	name = cleanPath(name)
+	var fsys fs.FS
+	prefix := ""
+
+	if found, mount := host.isPathInMount(name); found {
+		fsys = mount.fsys
+		prefix = mount.mountPoint
+	} else {
+		fsys = host.MutableFS
+	}
+
+	chownableFS, ok := fsys.(interface {
+		Chown(name string, uid, gid int) error
+	})
+	if !ok {
+		return &fs.PathError{Op: "chown", Path: name, Err: errors.ErrUnsupported}
+	}
+	return chownableFS.Chown(trimMountPoint(name, prefix), uid, gid)
+}
+
+func (host *FS) Chtimes(name string, atime time.Time, mtime time.Time) error {
+	name = cleanPath(name)
+	var fsys fs.FS
+	prefix := ""
+
+	if found, mount := host.isPathInMount(name); found {
+		fsys = mount.fsys
+		prefix = mount.mountPoint
+	} else {
+		fsys = host.MutableFS
+	}
+
+	chtimesableFS, ok := fsys.(interface {
+		Chtimes(name string, atime time.Time, mtime time.Time) error
+	})
+	if !ok {
+		return &fs.PathError{Op: "chtimes", Path: name, Err: errors.ErrUnsupported}
+	}
+	return chtimesableFS.Chtimes(trimMountPoint(name, prefix), atime, mtime)
+}
+
+func (host *FS) Create(name string) (fs.File, error) {
+	name = cleanPath(name)
+	var fsys fs.FS
+	prefix := ""
+
+	if found, mount := host.isPathInMount(name); found {
+		fsys = mount.fsys
+		prefix = mount.mountPoint
+	} else {
+		fsys = host.MutableFS
+	}
+
+	createableFS, ok := fsys.(interface {
+		Create(name string) (fs.File, error)
+	})
+	if !ok {
+		return nil, &fs.PathError{Op: "create", Path: name, Err: errors.ErrUnsupported}
+	}
+	return createableFS.Create(trimMountPoint(name, prefix))
+}
+
+func (host *FS) Mkdir(name string, perm fs.FileMode) error {
+	name = cleanPath(name)
+	var fsys fs.FS
+	prefix := ""
+
+	if found, mount := host.isPathInMount(name); found {
+		fsys = mount.fsys
+		prefix = mount.mountPoint
+	} else {
+		fsys = host.MutableFS
+	}
+
+	mkdirableFS, ok := fsys.(interface {
+		Mkdir(name string, perm fs.FileMode) error
+	})
+	if !ok {
+		return &fs.PathError{Op: "mkdir", Path: name, Err: errors.ErrUnsupported}
+	}
+	return mkdirableFS.Mkdir(trimMountPoint(name, prefix), perm)
+}
+
+func (host *FS) MkdirAll(path string, perm fs.FileMode) error {
+	path = cleanPath(path)
+	var fsys fs.FS
+	prefix := ""
+
+	if found, mount := host.isPathInMount(path); found {
+		fsys = mount.fsys
+		prefix = mount.mountPoint
+	} else {
+		fsys = host.MutableFS
+	}
+
+	mkdirableFS, ok := fsys.(interface {
+		MkdirAll(path string, perm fs.FileMode) error
+	})
+	if !ok {
+		return &fs.PathError{Op: "mkdirAll", Path: path, Err: errors.ErrUnsupported}
+	}
+	return mkdirableFS.MkdirAll(trimMountPoint(path, prefix), perm)
+}
+
+func (host *FS) Open(name string) (fs.File, error) {
+	name = cleanPath(name)
+	if found, mount := host.isPathInMount(name); found {
+		return mount.fsys.Open(trimMountPoint(name, mount.mountPoint))
+	}
+
+	return host.MutableFS.Open(name)
+}
+
+func (host *FS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error) {
+	if found, mount := host.isPathInMount(name); found {
+		return fsutil.OpenFile(mount.fsys, trimMountPoint(name, mount.mountPoint), flag, perm)
+	} else {
+		return fsutil.OpenFile(host.MutableFS, name, flag, perm)
+	}
+}
+
+type removableFS interface {
+	fs.FS
+	Remove(name string) error
+}
+
+func (host *FS) Remove(name string) error {
+	name = cleanPath(name)
+	var fsys fs.FS
+	prefix := ""
+
+	if found, mount := host.isPathInMount(name); found {
+		if name == mount.mountPoint {
+			return &fs.PathError{Op: "remove", Path: name, Err: syscall.EBUSY}
+		}
+
+		fsys = mount.fsys
+		prefix = mount.mountPoint
+	} else {
+		fsys = host.MutableFS
+	}
+
+	if removableFS, ok := fsys.(removableFS); ok {
+		return removableFS.Remove(trimMountPoint(name, prefix))
+	} else {
+		return &fs.PathError{Op: "remove", Path: name, Err: errors.ErrUnsupported}
+	}
+}
+
+func (host *FS) RemoveAll(path string) error {
+	path = cleanPath(path)
+	var fsys fs.FS
+	prefix := ""
+
+	if found, mount := host.isPathInMount(path); found {
+		if path == mount.mountPoint {
+			return &fs.PathError{Op: "removeAll", Path: path, Err: syscall.EBUSY}
+		}
+
+		fsys = mount.fsys
+		prefix = mount.mountPoint
+	} else {
+		fsys = host.MutableFS
+		// check if path contains any mountpoints, and call a custom removeAll
+		// if it does.
+		var mntPoints []string
+		for _, m := range host.mounts {
+			if path == "." || strings.HasPrefix(m.mountPoint, path) {
+				mntPoints = append(mntPoints, m.mountPoint)
+			}
+		}
+
+		if len(mntPoints) > 0 {
+			return removeAll(host, path, mntPoints)
+		}
+	}
+
+	rmAllFS, ok := fsys.(interface {
+		RemoveAll(path string) error
+	})
+	if !ok {
+		if rmFS, ok := fsys.(removableFS); ok {
+			return removeAll(rmFS, path, nil)
+		} else {
+			return &fs.PathError{Op: "removeAll", Path: path, Err: errors.ErrUnsupported}
+		}
+	}
+	return rmAllFS.RemoveAll(trimMountPoint(path, prefix))
+}
+
+// RemoveAll removes path and any children it contains. It removes everything
+// it can but returns the first error it encounters. If the path does not exist,
+// RemoveAll returns nil (no error). If there is an error, it will be of type *PathError.
+// Additionally, this function errors if attempting to remove a mountpoint.
+func removeAll(fsys removableFS, path string, mntPoints []string) error {
+	path = filepath.Clean(path)
+
+	if exists, err := fsutil.Exists(fsys, path); !exists || err != nil {
+		return err
+	}
+
+	return rmRecurse(fsys, path, mntPoints)
+
+}
+
+func rmRecurse(fsys removableFS, path string, mntPoints []string) error {
+	if mntPoints != nil && slices.Contains(mntPoints, path) {
+		return &fs.PathError{Op: "remove", Path: path, Err: syscall.EBUSY}
+	}
+
+	isdir, dirErr := fsutil.IsDir(fsys, path)
+	if dirErr != nil {
+		return dirErr
+	}
+
+	if isdir {
+		if entries, err := fs.ReadDir(fsys, path); err == nil {
+			for _, entry := range entries {
+				entryPath := filepath.Join(path, entry.Name())
+
+				if err := rmRecurse(fsys, entryPath, mntPoints); err != nil {
+					return err
+				}
+
+				if err := fsys.Remove(entryPath); err != nil {
+					return err
+				}
+			}
+		} else {
+			return err
+		}
+	}
+
+	return fsys.Remove(path)
+}
+
+func (host *FS) Rename(oldname, newname string) error {
+	oldname = cleanPath(oldname)
+	newname = cleanPath(newname)
+	var fsys fs.FS
+	prefix := ""
+
+	// error if both paths aren't in the same filesystem
+	if found, oldMount := host.isPathInMount(oldname); found {
+		if found, newMount := host.isPathInMount(newname); found {
+			if oldMount != newMount {
+				return &fs.PathError{Op: "rename", Path: oldname + " -> " + newname, Err: syscall.EXDEV}
+			}
+
+			if oldname == oldMount.mountPoint || newname == newMount.mountPoint {
+				return &fs.PathError{Op: "rename", Path: oldname + " -> " + newname, Err: syscall.EBUSY}
+			}
+
+			fsys = newMount.fsys
+			prefix = newMount.mountPoint
+		} else {
+			return &fs.PathError{Op: "rename", Path: oldname + " -> " + newname, Err: syscall.EXDEV}
+		}
+	} else {
+		if found, _ := host.isPathInMount(newname); found {
+			return &fs.PathError{Op: "rename", Path: oldname + " -> " + newname, Err: syscall.EXDEV}
+		}
+
+		fsys = host.MutableFS
+	}
+
+	renameableFS, ok := fsys.(interface {
+		Rename(oldname, newname string) error
+	})
+	if !ok {
+		return &fs.PathError{Op: "rename", Path: oldname + " -> " + newname, Err: errors.ErrUnsupported}
+	}
+	return renameableFS.Rename(trimMountPoint(oldname, prefix), trimMountPoint(newname, prefix))
+}

--- a/internal/mountablefs/mountablefs_test.go
+++ b/internal/mountablefs/mountablefs_test.go
@@ -1,0 +1,230 @@
+package mountablefs
+
+import (
+	"io/fs"
+	"testing"
+
+	"tractor.dev/toolkit-go/engine/fs/fstest"
+	"tractor.dev/toolkit-go/engine/fs/memfs"
+)
+
+func TestMountUnmount(t *testing.T) {
+	host := memfs.New()
+	mnt := memfs.New()
+
+	fstest.WriteFS(t, host, map[string]string{
+		"all":             "host",
+		"mount/host-data": "host",
+	})
+
+	fstest.WriteFS(t, mnt, map[string]string{
+		"all2":         "mounted",
+		"rickroll.mpv": "mounted",
+	})
+
+	fsys := New(host)
+	if err := fsys.Mount(mnt, "mount"); err != nil {
+		t.Fatal(err)
+	}
+
+	fstest.CheckFS(t, fsys, map[string]string{
+		"all":                "host",
+		"mount/all2":         "mounted",
+		"mount/rickroll.mpv": "mounted",
+	})
+
+	if _, err := fsys.Open("mount/host-data"); err == nil {
+		t.Fatalf("Open: expected file %s to be masked by mount: got nil, expected %v", "mount/host-data", fs.ErrNotExist)
+	}
+
+	if err := fsys.Unmount("all"); err == nil {
+		t.Fatal("Unmount: expected error when attempting to Unmount a non-mountpoint, got nil")
+	}
+
+	if err := fsys.Unmount("mount"); err != nil {
+		t.Fatal(err)
+	}
+
+	fstest.CheckFS(t, fsys, map[string]string{
+		"all":             "host",
+		"mount/host-data": "host",
+	})
+
+	if _, err := fsys.Open("mount/rickroll.mpv"); err == nil {
+		t.Fatalf("Open: unexpected file %s: expected error %v", "mount/rickroll.mpv", fs.ErrNotExist)
+	}
+}
+
+func TestRemove(t *testing.T) {
+	host := memfs.New()
+	mnt := memfs.New()
+
+	fstest.WriteFS(t, host, map[string]string{
+		"A/B":      "host",
+		"C/D/blah": "host",
+	})
+
+	fstest.WriteFS(t, mnt, map[string]string{
+		"E/F": "mounted",
+		"G/H": "mounted",
+	})
+
+	fsys := New(host)
+	if err := fsys.Mount(mnt, "C/D"); err != nil {
+		t.Fatal(err)
+	}
+
+	fstest.CheckFS(t, fsys, map[string]string{
+		"A/B":     "host",
+		"C/D/E/F": "mounted",
+		"C/D/G/H": "mounted",
+	})
+
+	if err := fsys.Remove("A/B"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Remove("C/D/E/F"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.RemoveAll("C/D/G"); err != nil {
+		t.Fatal(err)
+	}
+
+	fstest.CheckFS(t, fsys, map[string]string{
+		// dirs are empty strings
+		"A/":     "",
+		"C/D/E/": "",
+	})
+
+	if err := fsys.Remove("A/B"); err == nil {
+		t.Fatalf("Remove: expected attempt to Remove a non-existant file to fail")
+	}
+
+	if err := fsys.Remove("C/D/G"); err == nil {
+		t.Fatalf("Remove: expected attempt to Remove a non-existant file to fail")
+	}
+
+	if err := fsys.Remove("C/D"); err == nil {
+		t.Fatalf("Remove: expected attempt to Remove a mount-point file to fail")
+	}
+
+	if err := fsys.RemoveAll("C/D"); err == nil {
+		t.Fatalf("RemoveAll: expected attempt to RemoveAll a mount-point file to fail")
+	}
+
+	if err := fsys.RemoveAll("/"); err == nil {
+		t.Fatalf("RemoveAll: expected attempt to RemoveAll a path containing a mount-point file to fail")
+	}
+
+	fstest.CheckFS(t, fsys, map[string]string{
+		// dirs are empty strings
+		"C/D/E/": "",
+	})
+
+	if err := fsys.Unmount("C/D"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRename(t *testing.T) {
+	host := memfs.New()
+	mnt := memfs.New()
+
+	fstest.WriteFS(t, host, map[string]string{
+		"all":             "host",
+		"mount/host-data": "host",
+	})
+
+	fstest.WriteFS(t, mnt, map[string]string{
+		"all2":         "mounted",
+		"rickroll.mpv": "mounted",
+	})
+
+	fsys := New(host)
+	if err := fsys.Mount(mnt, "mount"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Rename("all", "none"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Rename("mount/all2", "mount/none2"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Rename("mount/rickroll.mpv", "rickroll.mpv"); err == nil {
+		t.Fatalf("Rename: expected error when attempting to rename across filesystems")
+	}
+
+    if err := fsys.Rename("mount", "not-a-mount"); err == nil {
+        t.Fatalf("Rename: expected error when attempting to rename a mountpoint")
+    }
+
+	fstest.CheckFS(t, fsys, map[string]string{
+		"none":               "host",
+		"mount/none2":        "mounted",
+		"mount/rickroll.mpv": "mounted",
+	})
+
+	if err := fsys.Unmount("mount"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMkdir(t *testing.T) {
+	host := memfs.New()
+	mnt := memfs.New()
+
+	fstest.WriteFS(t, host, map[string]string{
+		"all":             "host",
+		"mount/host-data": "host",
+	})
+
+	fstest.WriteFS(t, mnt, map[string]string{
+		"all2":         "mounted",
+		"rickroll.mpv": "mounted",
+	})
+
+	fsys := New(host)
+	if err := fsys.Mount(mnt, "mount"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Mkdir("all/new-host-dir", 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Mkdir("mount/secret_tunnel", 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// TODO: memfs has incorrect behavior for creating and checking parents, so until
+	// it's fixed I'm leaving these commented. They're really testing the underlying
+	// filesystem implementation anyway.
+	// if err := fsys.Mkdir("mount/rickroll.mpv/nope", 0755); err == nil {
+	//     t.Fatalf("Mkdir: expected error when attempting to make a directory under a file")
+	// }
+
+	// if err := fsys.Mkdir("mount/hello/goodbye", 0755); err == nil {
+	//     t.Fatalf("Mkdir: expected error when attempting to make a directory with missing parents")
+	// }
+
+	if err := fsys.MkdirAll("mount/secret_tunnel/super_secret/deadend", 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	fstest.CheckFS(t, fsys, map[string]string{
+		// dirs are empty strings
+		"all/new-host-dir/":  "",
+		"mount/all2":         "mounted",
+		"mount/rickroll.mpv": "mounted",
+		"mount/secret_tunnel/super_secret/deadend/": "",
+	})
+
+	if err := fsys.Unmount("mount"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/kernel/fs/fs.go
+++ b/kernel/fs/fs.go
@@ -15,7 +15,7 @@ import (
 	"tractor.dev/wanix/internal/indexedfs"
 	"tractor.dev/wanix/internal/jsutil"
 
-	"tractor.dev/toolkit-go/engine/fs/mountablefs"
+	"tractor.dev/wanix/internal/mountablefs"
 )
 
 func log(args ...any) {


### PR DESCRIPTION
Pulling in `mountablefs` from toolkit-go since it's not quite finished and it'll be easier to develop here for now. Also dropped the go.mod replacement that assumes you have toolkit-go cloned next to this repo. 