### PR TITLE
Devfs

### DIFF
--- a/dev/bootloader.js
+++ b/dev/bootloader.js
@@ -89,15 +89,15 @@ if (!globalThis["ServiceWorkerGlobalScope"]) {
     }
     // TODO: define these in one place. duplicated in initdata.go
     await Promise.all([
-      load("/~dev/kernel/web/lib/duplex.js"),
-      load("/~dev/kernel/web/lib/worker.js"),
-      load("/~dev/kernel/web/lib/syscall.js"),
-      load("/~dev/kernel/web/lib/task.js"),
-      load("/~dev/kernel/web/lib/wasm.js"),
-      load("/~dev/kernel/web/lib/host.js"),
-      load("/~dev/internal/indexedfs/indexedfs.js"), // maybe load from kernel?
-      load("/~dev/local/bin/kernel"),
-      load("/~dev/local/bin/shell"),
+      load("/sys/dev/kernel/web/lib/duplex.js"),
+      load("/sys/dev/kernel/web/lib/worker.js"),
+      load("/sys/dev/kernel/web/lib/syscall.js"),
+      load("/sys/dev/kernel/web/lib/task.js"),
+      load("/sys/dev/kernel/web/lib/wasm.js"),
+      load("/sys/dev/kernel/web/lib/host.js"),
+      load("/sys/dev/internal/indexedfs/indexedfs.js"), // maybe load from kernel?
+      load("/sys/dev/local/bin/kernel"),
+      load("/sys/dev/local/bin/shell"),
     ]);
     
     globalThis.duplex = await import(URL.createObjectURL(initfs["duplex.js"]));
@@ -140,7 +140,6 @@ if (globalThis["ServiceWorkerGlobalScope"] && self instanceof ServiceWorkerGloba
       url.pathname === "/" ||
       url.pathname === "/wanix-bootloader.js" ||
       url.pathname === "/favicon.ico" || 
-      url.pathname.startsWith("/~dev") || // deprecated
       url.pathname.startsWith("/sys/dev") || 
       url.pathname.startsWith("/bootloader") || 
       url.pathname.startsWith("/index.html") ||

--- a/dev/bootloader.js
+++ b/dev/bootloader.js
@@ -140,7 +140,8 @@ if (globalThis["ServiceWorkerGlobalScope"] && self instanceof ServiceWorkerGloba
       url.pathname === "/" ||
       url.pathname === "/wanix-bootloader.js" ||
       url.pathname === "/favicon.ico" || 
-      url.pathname.startsWith("/~dev") || 
+      url.pathname.startsWith("/~dev") || // deprecated
+      url.pathname.startsWith("/sys/dev") || 
       url.pathname.startsWith("/bootloader") || 
       url.pathname.startsWith("/index.html") ||
       !host) return;

--- a/dev/server.go
+++ b/dev/server.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"os"
 	"time"
+
+	"tractor.dev/wanix/internal/httpfs"
 )
 
 func loggerMiddleware(next http.Handler) http.Handler {
@@ -27,7 +29,8 @@ func main() {
 	log.Println("Serving WANIX dev server at http://localhost:7777 ...")
 
 	mux := http.NewServeMux()
-	mux.Handle("/~dev/", http.StripPrefix("/~dev", http.FileServer(http.Dir(dir))))
+	mux.Handle("/sys/dev/", http.StripPrefix("/sys/dev/", httpfs.FileServer(os.DirFS(dir))))
+	mux.Handle("/~dev/", http.StripPrefix("/~dev", http.FileServer(http.Dir(dir)))) // deprecated
 	mux.Handle("/wanix-bootloader.js", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("content-type", "application/javascript")
 

--- a/dev/server.go
+++ b/dev/server.go
@@ -30,7 +30,6 @@ func main() {
 
 	mux := http.NewServeMux()
 	mux.Handle("/sys/dev/", http.StripPrefix("/sys/dev/", httpfs.FileServer(os.DirFS(dir))))
-	mux.Handle("/~dev/", http.StripPrefix("/~dev", http.FileServer(http.Dir(dir)))) // deprecated
 	mux.Handle("/wanix-bootloader.js", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("content-type", "application/javascript")
 

--- a/internal/app/terminal/index.html
+++ b/internal/app/terminal/index.html
@@ -1,8 +1,8 @@
 <html>
 <head>
-  <link rel="stylesheet" href="/~dev/kernel/web/vnd/xterm/xterm-5.3.0.min.css" />
-  <script src="/~dev/kernel/web/vnd/xterm/xterm-5.3.0.min.js"></script>
-  <script src="/~dev/kernel/web/vnd/xterm/xterm-fit-0.8.0.min.js"></script>
+  <link rel="stylesheet" href="/sys/dev/kernel/web/vnd/xterm/xterm-5.3.0.min.css" />
+  <script src="/sys/dev/kernel/web/vnd/xterm/xterm-5.3.0.min.js"></script>
+  <script src="/sys/dev/kernel/web/vnd/xterm/xterm-fit-0.8.0.min.js"></script>
   <style>
     .xterm .xterm-viewport {
       /* On OS X this is required in order for the scroll bar to appear fully opaque */

--- a/internal/fsutil/copy.go
+++ b/internal/fsutil/copy.go
@@ -1,0 +1,106 @@
+package fsutil
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"tractor.dev/toolkit-go/engine/fs"
+)
+
+// CopyAll recursively copies the file, directory or symbolic link at src
+// to dst. The destination must not exist. Symbolic links are not
+// followed.
+//
+// If the copy fails half way through, the destination might be left
+// partially written.
+func CopyAll(fsys fs.MutableFS, src, dst string) error {
+	srcInfo, srcErr := fs.Stat(fsys, src)
+	if srcErr != nil {
+		return srcErr
+	}
+	dstInfo, dstErr := fs.Stat(fsys, dst)
+	if dstErr == nil {
+		fmt.Println(dst, dstInfo.Name())
+		return fmt.Errorf("will not overwrite %q", dst)
+	}
+	if !os.IsNotExist(dstErr) {
+		return dstErr
+	}
+	switch mode := srcInfo.Mode(); mode & fs.ModeType {
+	// case os.ModeSymlink:
+	// 	return copySymLink(src, dst)
+	case os.ModeDir:
+		return copyDir(fsys, src, dst, mode)
+	case 0:
+		return copyFile(fsys, src, dst, mode)
+	default:
+		return fmt.Errorf("cannot copy file with mode %v", mode)
+	}
+}
+
+// func copySymLink(src, dst string) error {
+// 	target, err := os.Readlink(src)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	return os.Symlink(target, dst)
+// }
+
+func copyFile(fsys fs.MutableFS, src, dst string, mode fs.FileMode) error {
+	srcf, err := fsys.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcf.Close()
+	dstf, err := fsys.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode.Perm())
+	if err != nil {
+		return err
+	}
+	defer dstf.Close()
+	// Make the actual permissions match the source permissions
+	// even in the presence of umask.
+	if err := fsys.Chmod(dst, mode.Perm()); err != nil {
+		return err
+	}
+	wdstf, ok := dstf.(io.Writer)
+	if !ok {
+		return fmt.Errorf("cannot copy %q to %q: dst not writable", src, dst)
+	}
+	if _, err := io.Copy(wdstf, srcf); err != nil {
+		return fmt.Errorf("cannot copy %q to %q: %v", src, dst, err)
+	}
+	return nil
+}
+
+func copyDir(fsys fs.MutableFS, src, dst string, mode fs.FileMode) error {
+	srcf, err := fsys.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcf.Close()
+	if mode&0500 == 0 {
+		// The source directory doesn't have write permission,
+		// so give the new directory write permission anyway
+		// so that we have permission to create its contents.
+		// We'll make the permissions match at the end.
+		mode |= 0500
+	}
+	if err := fsys.Mkdir(dst, mode.Perm()); err != nil {
+		return err
+	}
+	entries, err := fs.ReadDir(fsys, src)
+	if err != nil {
+		return fmt.Errorf("error reading directory %q: %v", src, err)
+	}
+	for _, entry := range entries {
+		if err := CopyAll(fsys, filepath.Join(src, entry.Name()), filepath.Join(dst, entry.Name())); err != nil {
+			return err
+		}
+	}
+	if err := fsys.Chmod(dst, mode.Perm()); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/httpfs/httpfs.go
+++ b/internal/httpfs/httpfs.go
@@ -1,0 +1,189 @@
+// httpfs is a read-only filesystem built on top of HTTP
+package httpfs
+
+import (
+	"encoding/json"
+	"io"
+	"io/fs"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// FileServer wraps http.FileServer with extra endpoints for metadata.
+// Requests to dir paths with `?readdir` will a return JSON array of dir entries.
+// Requests to paths with `?stat` will return a JSON object of file info.
+func FileServer(fsys fs.FS) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		name := strings.TrimSuffix(r.URL.Path, "/")
+		if name == "" {
+			name = "."
+		}
+		fi, err := fs.Stat(fsys, name)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		if r.URL.RawQuery == "stat" {
+			b, err := json.Marshal(map[string]any{
+				"isDir":   fi.IsDir(),
+				"mode":    uint(fi.Mode()),
+				"size":    fi.Size(),
+				"name":    fi.Name(),
+				"modTime": fi.ModTime().Unix(),
+			})
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("content-type", "application/json")
+			w.Write(b)
+			return
+		}
+
+		if fi.IsDir() && r.URL.RawQuery == "readdir" {
+			de, err := fs.ReadDir(fsys, name)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			var dir []string
+			for _, e := range de {
+				if e.IsDir() {
+					dir = append(dir, e.Name()+"/")
+				} else {
+					dir = append(dir, e.Name())
+				}
+			}
+			b, err := json.Marshal(dir)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("content-type", "application/json")
+			w.Write(b)
+			return
+		}
+
+		http.FileServer(http.FS(fsys)).ServeHTTP(w, r)
+	})
+}
+
+type FS struct {
+	baseURL string
+}
+
+func New(baseURL string) *FS {
+	return &FS{baseURL}
+}
+
+func (fsys *FS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error) {
+	return fsys.Open(name)
+}
+
+func (fsys *FS) Open(name string) (fs.File, error) {
+	url := filepath.Join(fsys.baseURL, name)
+	resp, err := http.DefaultClient.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	return &file{
+		ReadCloser: resp.Body,
+		Name:       name,
+		FS:         fsys,
+	}, nil
+}
+
+func (fsys *FS) stat(name string) (*info, error) {
+	url := filepath.Join(fsys.baseURL, name)
+	resp, err := http.DefaultClient.Get(url + "?stat")
+	if err != nil {
+		return nil, err
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+	m := map[string]any{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
+	return &info{
+		name:    m["name"].(string),
+		size:    int64(m["size"].(float64)),
+		mode:    uint(m["mode"].(float64)),
+		modTime: int64(m["modTime"].(float64)),
+		isDir:   m["isDir"].(bool),
+	}, nil
+}
+
+func (fsys *FS) Stat(name string) (fs.FileInfo, error) {
+	return fsys.stat(name)
+}
+
+func (fsys *FS) ReadDir(name string) ([]fs.DirEntry, error) {
+	url := filepath.Join(fsys.baseURL, name)
+	resp, err := http.DefaultClient.Get(url + "?readdir")
+	if err != nil {
+		return nil, err
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+	dir := []any{}
+	if err := json.Unmarshal(b, &dir); err != nil {
+		return nil, err
+	}
+
+	var out []fs.DirEntry
+	for _, sub := range dir {
+		info, err := fsys.stat(filepath.Join(name, sub.(string)))
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, info)
+	}
+	return out, nil
+}
+
+type file struct {
+	io.ReadCloser
+	Name string
+	FS   *FS
+}
+
+func (f *file) Stat() (fs.FileInfo, error) {
+	return f.FS.Stat(f.Name)
+}
+
+func (f *file) ReadDir(n int) ([]fs.DirEntry, error) {
+	return f.FS.ReadDir(f.Name)
+}
+
+type info struct {
+	name    string
+	size    int64
+	mode    uint
+	modTime int64
+	isDir   bool
+}
+
+func (i *info) Name() string       { return i.name }
+func (i *info) Size() int64        { return i.size }
+func (i *info) Mode() fs.FileMode  { return fs.FileMode(i.mode) }
+func (i *info) ModTime() time.Time { return time.Unix(i.modTime, 0) }
+func (i *info) IsDir() bool        { return i.isDir }
+func (i *info) Sys() any           { return nil }
+
+// these allow it to act as DirInfo as well
+func (i *info) Info() (fs.FileInfo, error) {
+	return i, nil
+}
+func (i *info) Type() fs.FileMode {
+	return i.Mode()
+}

--- a/internal/indexedfs/indexedfs.go
+++ b/internal/indexedfs/indexedfs.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"tractor.dev/toolkit-go/engine/fs"
-	"tractor.dev/toolkit-go/engine/fs/fsutil"
 	"tractor.dev/wanix/internal/jsutil"
 )
 
@@ -73,7 +72,7 @@ func (ifs *FS) Mkdir(name string, perm fs.FileMode) error {
 	}
 	dir := filepath.Dir(name)
 	if dir != "." && dir != "/" {
-		exists, err := fsutil.DirExists(ifs, dir)
+		exists, err := fs.DirExists(ifs, dir)
 		if err != nil {
 			return err
 		}
@@ -96,7 +95,7 @@ func (ifs *FS) MkdirAll(path string, perm fs.FileMode) error {
 		}
 		pp = append(pp, p)
 		dir := filepath.Join(pp...)
-		exists, err := fsutil.DirExists(ifs, dir)
+		exists, err := fs.DirExists(ifs, dir)
 		if err != nil {
 			return err
 		}

--- a/internal/osfs/osfs.go
+++ b/internal/osfs/osfs.go
@@ -1,0 +1,81 @@
+// TODO: move into toolkit-go
+package osfs
+
+import (
+	"os"
+	"time"
+
+	"tractor.dev/toolkit-go/engine/fs"
+)
+
+type FS struct{}
+
+func New() *FS {
+	return &FS{}
+}
+
+func (FS) Create(name string) (fs.File, error) {
+	f, e := os.Create(name)
+	if f == nil {
+		// while this looks strange, we need to return a bare nil (of type nil) not
+		// a nil value of type *os.File or nil won't be nil
+		return nil, e
+	}
+	return f, e
+}
+
+func (FS) Mkdir(name string, perm fs.FileMode) error {
+	return os.Mkdir(name, perm)
+}
+
+func (FS) MkdirAll(path string, perm fs.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+func (FS) Open(name string) (fs.File, error) {
+	f, e := os.Open(name)
+	if f == nil {
+		// while this looks strange, we need to return a bare nil (of type nil) not
+		// a nil value of type *os.File or nil won't be nil
+		return nil, e
+	}
+	return f, e
+}
+
+func (FS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error) {
+	f, e := os.OpenFile(name, flag, perm)
+	if f == nil {
+		// while this looks strange, we need to return a bare nil (of type nil) not
+		// a nil value of type *os.File or nil won't be nil
+		return nil, e
+	}
+	return f, e
+}
+
+func (FS) Remove(name string) error {
+	return os.Remove(name)
+}
+
+func (FS) RemoveAll(path string) error {
+	return os.RemoveAll(path)
+}
+
+func (FS) Rename(oldname, newname string) error {
+	return os.Rename(oldname, newname)
+}
+
+func (FS) Stat(name string) (fs.FileInfo, error) {
+	return os.Stat(name)
+}
+
+func (FS) Chmod(name string, mode fs.FileMode) error {
+	return os.Chmod(name, mode)
+}
+
+func (FS) Chown(name string, uid, gid int) error {
+	return os.Chown(name, uid, gid)
+}
+
+func (FS) Chtimes(name string, atime time.Time, mtime time.Time) error {
+	return os.Chtimes(name, atime, mtime)
+}

--- a/kernel/fs/fs.go
+++ b/kernel/fs/fs.go
@@ -16,7 +16,6 @@ import (
 	"tractor.dev/wanix/internal/httpfs"
 	"tractor.dev/wanix/internal/indexedfs"
 	"tractor.dev/wanix/internal/jsutil"
-
 	"tractor.dev/wanix/internal/mountablefs"
 )
 
@@ -52,6 +51,8 @@ func (s *Service) Initialize() {
 	fs.MkdirAll(s.fsys, "app", 0755)
 	fs.MkdirAll(s.fsys, "cmd", 0755)
 	fs.MkdirAll(s.fsys, "sys", 0755)
+	fs.MkdirAll(s.fsys, "sys/app", 0755)
+	fs.MkdirAll(s.fsys, "sys/cmd", 0755)
 
 	devURL := fmt.Sprintf("%ssys/dev", js.Global().Get("hostURL").String())
 	resp, err := http.DefaultClient.Get(devURL)
@@ -603,7 +604,8 @@ func (s *Service) unlink(this js.Value, args []js.Value) any {
 	go func() {
 		log("unlink", path)
 
-		if err := s.fsys.Remove(path); err != nil {
+		// GOOS=js calls unlink for os.RemoveAll so we use RemoveAll here
+		if err := s.fsys.RemoveAll(path); err != nil {
 			cb.Invoke(jsutil.ToJSError(err))
 			return
 		}

--- a/kernel/proc/exec/exec.go
+++ b/kernel/proc/exec/exec.go
@@ -1,3 +1,6 @@
+// exec is a cheap knock-off of os/exec to be used by userland programs
+// to spawn subprocesses with the wanix kernel. Perhaps with WASI support
+// it will be unnecessary as the os/exec can be used directly instead.
 package exec
 
 import (
@@ -10,8 +13,6 @@ import (
 
 	"tractor.dev/wanix/internal/jsutil"
 )
-
-// cheap knock-off of os/exec
 
 type Cmd struct {
 	Path string

--- a/kernel/web/lib/task.js
+++ b/kernel/web/lib/task.js
@@ -23,6 +23,7 @@ export class Task {
       ppid: (globalThis.process) ? globalThis.process.pid : -1,
       fs: this.initfs,
       dir: opts.dir || "/",
+      hostURL: location.href,
     }});
     
     const taskReady = new Promise((resolve) => {

--- a/kernel/web/lib/worker.js
+++ b/kernel/web/lib/worker.js
@@ -6,6 +6,7 @@ addEventListener("message", async (e) => {
   if (e.data.duplex) return;
   if (e.data.init) {
     
+    globalThis.hostURL = e.data.init.hostURL;
     globalThis.initfs = e.data.init.fs;
     globalThis.process.pid = e.data.init.pid;
     globalThis.process.ppid = e.data.init.ppid;

--- a/kernel/web/ui.go
+++ b/kernel/web/ui.go
@@ -7,6 +7,6 @@ import (
 type UI struct{}
 
 func (s *UI) InitializeJS() {
-	js.Global().Get("sys").Call("call", "host.loadStylesheet", []any{"/~dev/kernel/web/ui/style.css"})
-	js.Global().Get("sys").Call("call", "host.loadApp", []any{"terminal", "/~dev/internal/app/terminal/index.html", true})
+	js.Global().Get("sys").Call("call", "host.loadStylesheet", []any{"/sys/dev/kernel/web/ui/style.css"})
+	js.Global().Get("sys").Call("call", "host.loadApp", []any{"terminal", "/sys/dev/internal/app/terminal", true})
 }

--- a/shell/main.go
+++ b/shell/main.go
@@ -38,6 +38,7 @@ func (m *Shell) Initialize() {
 	m.Root.AddCommand(mkdirCmd())
 	m.Root.AddCommand(moveCmd())
 	m.Root.AddCommand(copyCmd())
+	m.Root.AddCommand(copyCmd2()) // temporary
 	m.Root.AddCommand(pwdCmd())
 	m.Root.AddCommand(writeCmd())
 	m.Root.AddCommand(printEnvCmd())


### PR DESCRIPTION
This PR is mostly about setting up `/sys/dev` using a new read-only `httpfs` provided by the dev server to access project files. This will let us copy more files into the Wanix FS without going through initfs. It also replaces the special case HTTP path `/~dev` used to copy project files into initfs. Checking if `/sys/dev` exists now becomes the canonical way to check if in dev mode.

Package additions:
- `internal/httpfs`: a read-only FS implementation backed by HTTP with alternative to http.FileServer to provide necessary metadata.
- `internal/fsutil`: started a place for more fs utilities, namely CopyAll for recursive copies.
- `internal/osfs`: since os.DirFS returns a read-only fs.FS, here we implement a fs.MutableFS that just hands off to os package functions. This way we can use CopyAll with the "os" FS. 

This also sets up the standard system directories including the user "cmd" and "app" dirs at the root. The next step would be to copy apps from `/sys/dev/internal/app` to either `/app` or `/sys/app`, but there are issues with recursive copies.

If I were more organized I'd not have this included in this PR, but it turns out `GOOS=js` makes `os.RemoveAll` use the `unlink` operation, which we previously implemented with `Remove` in the kernel, and this was causing directories to be deleted in `indexedfs` but not their files. So recreating the dir would also introduce the old files, etc. This PR changes `unlink` to use `RemoveAll`, however there is now a bug (separate issue coming) with `indexedfs` where its `deleteAll` used by `RemoveAll` does not seem to be doing anything. Either way, deleting directories is broken, but now until `deleteAll` is fixed, any Remove or RemoveAll seems to be a no-op. 