### PR TITLE
CopyAll fix

### DIFF
--- a/internal/osfs/osfs.go
+++ b/internal/osfs/osfs.go
@@ -10,6 +10,8 @@ import (
 
 type FS struct{}
 
+// This file system is a passthrough for `os` calls, which expect rooted paths.
+// Pass OS paths, not io/fs paths.
 func New() *FS {
 	return &FS{}
 }

--- a/shell/builtin.go
+++ b/shell/builtin.go
@@ -305,7 +305,7 @@ func copyCmd2() *cli.Command {
 		Run: func(ctx *cli.Context, args []string) {
 			srcpath := args[0]
 			dstpath := args[1]
-			err := fsutil.CopyAll(osfs.New(), unixToFsPath(srcpath), unixToFsPath(dstpath))
+			err := fsutil.CopyAll(osfs.New(), absPath(srcpath), absPath(dstpath))
 			if checkErr(ctx, err) {
 				return
 			}


### PR DESCRIPTION
Closes #25 

Implemented `chmod` for `indexedfs`.
Changed `cp2` to use `absPath` for `osfs` path parameters, since it's just a passthrough for `os` calls.