### PR TITLE
Tree Command

### DIFF
--- a/internal/app/terminal/index.html
+++ b/internal/app/terminal/index.html
@@ -35,7 +35,7 @@
   const sys = parent.sys;
 
   const terminal = new Terminal({
-    scrollback: 0,
+    scrollback: 250,
     convertEol: true,
     fontSize: 20,
     fontFamily: "Menlo, Monaco, 'Courier New', monospace",

--- a/internal/app/terminal/index.html
+++ b/internal/app/terminal/index.html
@@ -35,7 +35,7 @@
   const sys = parent.sys;
 
   const terminal = new Terminal({
-    scrollback: 250,
+    scrollback: 500,
     convertEol: true,
     fontSize: 20,
     fontFamily: "Menlo, Monaco, 'Courier New', monospace",

--- a/shell/main.go
+++ b/shell/main.go
@@ -50,6 +50,7 @@ func (m *Shell) Initialize() {
 	m.cmd.AddCommand(writeCmd())
 	m.cmd.AddCommand(printEnvCmd())
 	m.cmd.AddCommand(exportCmd())
+	m.cmd.AddCommand(treeCmd())
 	m.cmd.Run = m.ExecuteCommand
 
 	m.defaultStdin = NewBlockingBuffer()


### PR DESCRIPTION
Closes #16 

This command walks the file system, creates a tree graph of it's structure, and prints that graph to the console. Generating the file tree can take a moment, especially if the file system is networked, so it'll print a loading message after a second to stderr to notify the user. 
This PR also enables terminal scrollback, 500 lines to be exact.

## Follow ups
Having options for excluding certain directories (e.g. `.gitignore`) or mounts would be nice. Currently it doesn't follow `.git/` or `/sys/dev/` unless you directly pass them as the argument.

Only printing directories would be useful as well.