### PR TITLE
Print version and add `WanixSyscall` helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ bundle: local/bin
 	go run -tags bundle ./dev
 
 kernel: kernel/main.go local/bin
-	cd kernel && GOOS=js GOARCH=wasm go build -ldflags="-X 'main.Version=${WANIX_VERSION}'" -o ../local/bin/kernel .
+	cd kernel && GOOS=js GOARCH=wasm go build -ldflags="-X 'main.version=${WANIX_VERSION}'" -o ../local/bin/kernel .
 
 shell: shell/main.go local/bin
 	cd shell && GOOS=js GOARCH=wasm go build -o ../local/bin/shell .

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: boot dev kernel shell dev bundle
 
+WANIX_VERSION=0.1
+
 all: kernel shell
 
 dev: all
@@ -9,7 +11,7 @@ bundle: local/bin
 	go run -tags bundle ./dev
 
 kernel: kernel/main.go local/bin
-	cd kernel && GOOS=js GOARCH=wasm go build -o ../local/bin/kernel .
+	cd kernel && GOOS=js GOARCH=wasm go build -ldflags="-X 'main.Version=${WANIX_VERSION}'" -o ../local/bin/kernel .
 
 shell: shell/main.go local/bin
 	cd shell && GOOS=js GOARCH=wasm go build -o ../local/bin/shell .

--- a/internal/jsutil/jsutil.go
+++ b/internal/jsutil/jsutil.go
@@ -8,6 +8,21 @@ import (
 	"syscall/js"
 )
 
+// Returns the syscall `response.value`.
+// To access the response itself see `WanixSyscallResp` instead.
+func WanixSyscall(fn string, args ...any) (js.Value, error) {
+	response, err := WanixSyscallResp(fn, args...)
+	if err != nil {
+		return js.Null(), err
+	}
+	return response.Get("value"), nil
+}
+
+// Useful for syscalls involving streams (i.e. stdio).
+func WanixSyscallResp(fn string, args ...any) (response js.Value, err error) {
+	return AwaitErr(js.Global().Get("sys").Call("call", fn, args))
+}
+
 func Await(promise js.Value) js.Value {
 	ch := make(chan js.Value, 1)
 	promise.Call("then", js.FuncOf(func(this js.Value, args []js.Value) any {

--- a/kernel/main.go
+++ b/kernel/main.go
@@ -12,6 +12,8 @@ import (
 	"tractor.dev/wanix/kernel/web"
 )
 
+var Version string
+
 func main() {
 	engine.Run(Kernel{},
 		proc.Service{},
@@ -35,6 +37,8 @@ func (m *Kernel) Run(ctx context.Context) error {
 	blob := js.Global().Get("initfs").Get("syscall.js")
 	url := js.Global().Get("URL").Call("createObjectURL", blob)
 	jsutil.Await(js.Global().Call("import", url))
+
+	js.Global().Set("wanixVersion", Version)
 
 	// initialize components
 	for _, c := range m.Components {

--- a/kernel/main.go
+++ b/kernel/main.go
@@ -12,7 +12,7 @@ import (
 	"tractor.dev/wanix/kernel/web"
 )
 
-var Version string
+var version string
 
 func main() {
 	engine.Run(Kernel{},
@@ -32,18 +32,29 @@ type Kernel struct {
 	Components []Component
 }
 
-func (m *Kernel) Run(ctx context.Context) error {
+func (k *Kernel) Run(ctx context.Context) error {
 	// import syscall.js
 	blob := js.Global().Get("initfs").Get("syscall.js")
 	url := js.Global().Get("URL").Call("createObjectURL", blob)
 	jsutil.Await(js.Global().Call("import", url))
 
-	js.Global().Set("wanixVersion", Version)
+	// expose syscalls
+	js.Global().Get("api").Set("kernel", map[string]any{
+		"version": js.FuncOf(k.version),
+	})
 
 	// initialize components
-	for _, c := range m.Components {
+	for _, c := range k.Components {
 		c.InitializeJS()
 	}
 
 	select {}
+}
+
+func (k *Kernel) Version() string {
+	return version
+}
+
+func (k *Kernel) version(this js.Value, args []js.Value) any {
+	return version
 }

--- a/kernel/web/lib/syscall.js
+++ b/kernel/web/lib/syscall.js
@@ -1,5 +1,10 @@
 
 globalThis.api = {
+  kernel: {
+    version() {
+      return globalThis.wanixVersion;
+    },
+  },
   host: {
     respondRPC: async (resp, call) => {
       // forward upstream to host page

--- a/kernel/web/lib/syscall.js
+++ b/kernel/web/lib/syscall.js
@@ -1,10 +1,5 @@
 
 globalThis.api = {
-  kernel: {
-    version() {
-      return globalThis.wanixVersion;
-    },
-  },
   host: {
     respondRPC: async (resp, call) => {
       // forward upstream to host page

--- a/kernel/web/lib/task.js
+++ b/kernel/web/lib/task.js
@@ -40,6 +40,7 @@ export class Task {
 
     // if in kernel worker
     if (globalThis.api) {
+      this.pipe.handle("kernel", duplex.handlerFrom(globalThis.api.kernel));
       this.pipe.handle("fs", duplex.handlerFrom(globalThis.api.fs));
       this.pipe.handle("proc", duplex.handlerFrom(globalThis.api.proc));
       this.pipe.handle("tty", duplex.handlerFrom(globalThis.api.tty));  

--- a/kernel/web/ui.go
+++ b/kernel/web/ui.go
@@ -1,12 +1,12 @@
 package web
 
 import (
-	"syscall/js"
+	"tractor.dev/wanix/internal/jsutil"
 )
 
 type UI struct{}
 
 func (s *UI) InitializeJS() {
-	js.Global().Get("sys").Call("call", "host.loadStylesheet", []any{"/sys/dev/kernel/web/ui/style.css"})
-	js.Global().Get("sys").Call("call", "host.loadApp", []any{"terminal", "/sys/dev/internal/app/terminal", true})
+	jsutil.WanixSyscall("host.loadStylesheet", "/sys/dev/kernel/web/ui/style.css")
+	jsutil.WanixSyscall("host.loadApp", "terminal", "/sys/dev/internal/app/terminal", true)
 }

--- a/shell/main.go
+++ b/shell/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall/js"
 
 	"github.com/anmitsu/go-shlex"
 	"golang.org/x/term"
@@ -82,7 +81,7 @@ func (m *Shell) Run(ctx context.Context) (err error) {
 		}
 
 	} else {
-		wanixVersion := jsutil.Await(js.Global().Get("sys").Call("call", "kernel.version")).Get("value").String()
+		wanixVersion, _ := jsutil.WanixSyscall("kernel.version")
 		fmt.Printf(`
     ____    _____  _____     ___    __      __   ____   _
 |  |    |  |    /  \    |    \  |  | (_    _) \  \  /  / 
@@ -91,7 +90,7 @@ func (m *Shell) Run(ctx context.Context) (err error) {
  \  \/\/  /  |   __   | |  |  \    |  _|  |_   /  /\  \  
 __\      /___|  (__)  |_|  |___\   |_(      )_/  /__\  \_
                         -- v%s --
-`, wanixVersion)
+`, wanixVersion.String())
 
 		terminal := term.NewTerminal(struct {
 			io.Reader

--- a/shell/main.go
+++ b/shell/main.go
@@ -8,12 +8,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall/js"
 
 	"github.com/anmitsu/go-shlex"
 	"golang.org/x/term"
 	"tractor.dev/toolkit-go/engine"
 	"tractor.dev/toolkit-go/engine/cli"
 	"tractor.dev/toolkit-go/engine/fs"
+	"tractor.dev/wanix/internal/jsutil"
 	"tractor.dev/wanix/kernel/proc/exec"
 )
 
@@ -79,15 +81,17 @@ func (m *Shell) Run(ctx context.Context) (err error) {
 		}
 
 	} else {
-		fmt.Println(`
+		wanixVersion := jsutil.Await(js.Global().Get("sys").Call("call", "kernel.version")).Get("value").String()
+		fmt.Printf(`
     ____    _____  _____     ___    __      __   ____   _
 |  |    |  |    /  \    |    \  |  | (_    _) \  \  /  / 
 |  |    |  |   /    \   |  |\ \ |  |   |  |    \  \/  /  
 |  |    |  |  /  ()  \  |  | \ \|  |   |  |     >    <   
  \  \/\/  /  |   __   | |  |  \    |  _|  |_   /  /\  \  
 __\      /___|  (__)  |_|  |___\   |_(      )_/  /__\  \_
-																																		
-`)
+                        -- v%s --
+`, wanixVersion)
+
 		terminal := term.NewTerminal(struct {
 			io.Reader
 			io.Writer


### PR DESCRIPTION
Closes #35 
Added `kernel.version` syscall. The kernel version is set in the Makefile and linked into the build.

Added `WanixSyscall` helper to make syscalls easier and more readable. I switched syscalls to this new helper where applicable. Includes `WanixSyscallResp` to access the `response` itself as well.