### PR TITLE
Download command

### DIFF
--- a/kernel/web/lib/host.js
+++ b/kernel/web/lib/host.js
@@ -39,7 +39,6 @@ globalThis.sys.pipe.handle("host.loadApp", duplex.handlerFrom((target, path, foc
 }));
 
 globalThis.sys.pipe.handle("host.download", duplex.handlerFrom((filename, data) => {
-  console.log(data.byteLength);
   const blob = new Blob([data], {type: "application/octet-stream"});
   const url = URL.createObjectURL(blob);
   

--- a/kernel/web/lib/host.js
+++ b/kernel/web/lib/host.js
@@ -38,6 +38,21 @@ globalThis.sys.pipe.handle("host.loadApp", duplex.handlerFrom((target, path, foc
   frame.setAttribute("src", path);
 }));
 
+globalThis.sys.pipe.handle("host.download", duplex.handlerFrom((filename, data) => {
+  const blob = new Blob([data], {type: "application/octet-stream"});
+  const url = URL.createObjectURL(blob);
+  
+  const elem = document.createElement("a");
+  elem.setAttribute("download", filename);
+  elem.href = url;
+  elem.setAttribute("target", "_blank");
+  elem.click();
+
+  elem.remove();
+  URL.revokeObjectURL(url);
+}));
+
+
 const visorKeydown = (e) => {
   const el = document.querySelector("#terminal");
   if (e.code === "Backquote" && e.ctrlKey && el.classList.contains("visor")) {   

--- a/kernel/web/lib/host.js
+++ b/kernel/web/lib/host.js
@@ -39,6 +39,7 @@ globalThis.sys.pipe.handle("host.loadApp", duplex.handlerFrom((target, path, foc
 }));
 
 globalThis.sys.pipe.handle("host.download", duplex.handlerFrom((filename, data) => {
+  console.log(data.byteLength);
   const blob = new Blob([data], {type: "application/octet-stream"});
   const url = URL.createObjectURL(blob);
   

--- a/shell/download.go
+++ b/shell/download.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall/js"
+
+	"tractor.dev/toolkit-go/engine/cli"
+	"tractor.dev/toolkit-go/engine/fs"
+	"tractor.dev/wanix/internal/jsutil"
+)
+
+func downloadCmd() *cli.Command {
+	// TODO: compression flag
+	return &cli.Command{
+		Usage: "dl <path>",
+		Args:  cli.ExactArgs(1),
+		Short: "Download a Wanix file or directory to the host computer.",
+		Run: func(ctx *cli.Context, args []string) {
+			target := absPath(args[0])
+
+			fi, err := os.Stat(target)
+			if checkErr(ctx, err) {
+				return
+			}
+
+			var data []byte
+
+			if fi.IsDir() {
+				var buf bytes.Buffer
+				zw := zip.NewWriter(&buf)
+
+				err := fs.WalkDir(os.DirFS(target), ".", func(path string, d fs.DirEntry, walkErr error) error {
+					if walkErr != nil {
+						return walkErr
+					}
+					if path == "." {
+						return nil
+					}
+
+					name := path
+					if d.IsDir() {
+						name += "/"
+					}
+
+					fw, err := zw.Create(name)
+					if err != nil {
+						return err
+					}
+
+					if d.Type().IsRegular() {
+						file, err := os.Open(filepath.Join(target, path))
+						if err != nil {
+							return err
+						}
+
+						if _, err := io.Copy(fw, file); err != nil {
+							return err
+						}
+					}
+
+					return nil
+				})
+
+				if checkErr(ctx, err) {
+					return
+				}
+				if err = zw.Close(); checkErr(ctx, err) {
+					return
+				}
+
+				data = buf.Bytes()
+				target = target + ".zip"
+			} else {
+				data, err = os.ReadFile(target)
+				if checkErr(ctx, err) {
+					return
+				}
+			}
+
+			// TODO: there may be a more efficient way of doing this
+			// besides passing the file data. Initially we passed a
+			// blob but duplex complained about "Iterable/blob should be serialized as iterator".
+			// (related: BlobFromFile helper to avoid unecessary operations on indexedfs)
+
+			jsbuf := js.Global().Get("Uint8Array").New(len(data))
+			js.CopyBytesToJS(jsbuf, data)
+			_, err = jsutil.WanixSyscall("host.download", filepath.Base(target), jsbuf)
+			if checkErr(ctx, err) {
+				return
+			}
+		},
+	}
+}

--- a/shell/smallcmds.go
+++ b/shell/smallcmds.go
@@ -9,13 +9,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall/js"
-
-	// "syscall/js"
 
 	"tractor.dev/toolkit-go/engine/cli"
 	"tractor.dev/toolkit-go/engine/fs"
-	"tractor.dev/wanix/internal/jsutil"
 )
 
 func exitCmd() *cli.Command {
@@ -135,43 +131,6 @@ func reloadCmd() *cli.Command {
 		Run: func(ctx *cli.Context, args []string) {
 			fmt.Println("TODO: Unimplemented")
 			// js.Global().Get("wanix").Get("reload").Invoke()
-		},
-	}
-}
-
-func downloadCmd() *cli.Command {
-	return &cli.Command{
-		Usage: "dl <path>",
-		Args:  cli.ExactArgs(1),
-		Run: func(ctx *cli.Context, args []string) {
-			target := absPath(args[0])
-
-			fi, err := os.Stat(target)
-			if checkErr(ctx, err) {
-				return
-			}
-
-			if fi.IsDir() {
-				// TODO: tar the dir
-				// target = target + ".tar"
-			}
-
-			// TODO: there may be a more efficient way of doing this.
-			// Initially we passed a blob but duplex complained about
-			// "Iterable/blob should be serialized as iterator".
-			// (related: BlobFromFile helper to avoid unecessary operations on indexedfs)
-
-			data, err := os.ReadFile(target)
-			if checkErr(ctx, err) {
-				return
-			}
-
-			jsbuf := js.Global().Get("Uint8Array").New(len(data))
-			js.CopyBytesToJS(jsbuf, data)
-			_, err = jsutil.WanixSyscall("host.download", filepath.Base(target), jsbuf)
-			if checkErr(ctx, err) {
-				return
-			}
 		},
 	}
 }

--- a/shell/smallcmds.go
+++ b/shell/smallcmds.go
@@ -9,9 +9,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall/js"
+
+	// "syscall/js"
 
 	"tractor.dev/toolkit-go/engine/cli"
 	"tractor.dev/toolkit-go/engine/fs"
+	"tractor.dev/wanix/internal/jsutil"
 )
 
 func exitCmd() *cli.Command {
@@ -140,8 +144,34 @@ func downloadCmd() *cli.Command {
 		Usage: "dl <path>",
 		Args:  cli.ExactArgs(1),
 		Run: func(ctx *cli.Context, args []string) {
-			fmt.Println("TODO: Unimplemented")
-			// js.Global().Get("wanix").Get("download").Invoke(args[0])
+			target := absPath(args[0])
+
+			fi, err := os.Stat(target)
+			if checkErr(ctx, err) {
+				return
+			}
+
+			if fi.IsDir() {
+				// TODO: tar the dir
+				// target = target + ".tar"
+			}
+
+			// TODO: there may be a more efficient way of doing this.
+			// Initially we passed a blob but duplex complained about
+			// "Iterable/blob should be serialized as iterator".
+			// (related: BlobFromFile helper to avoid unecessary operations on indexedfs)
+
+			data, err := os.ReadFile(target)
+			if checkErr(ctx, err) {
+				return
+			}
+
+			jsbuf := js.Global().Get("Uint8Array").New(len(data))
+			js.CopyBytesToJS(jsbuf, data)
+			_, err = jsutil.WanixSyscall("host.download", filepath.Base(target), jsbuf)
+			if checkErr(ctx, err) {
+				return
+			}
 		},
 	}
 }


### PR DESCRIPTION
Closes #40
Allows downloading a file or directory to the host computer. 
Implementation deviates slightly as I had troubles getting `archive/tar` to work properly. Both `archive/tar` and `archive/zip` have issues writing subdirectories. Weirdly this only happens if not using compression, otherwise it works fine.

In the future we can debug this and add options for file and compression formats.