### PR TITLE
starts terminal resizing, adds env vars needed to start micro

### DIFF
--- a/internal/app/terminal/index.html
+++ b/internal/app/terminal/index.html
@@ -61,7 +61,8 @@
     const enc = new TextEncoder();
     const dec = new TextDecoder();
 
-    const resp = await sys.call("tty.open", ["shell", []]); //{ Term: "xterm-256color", Rows: 10, Cols: 80 });
+    const resp = await sys.call("tty.open", ["shell", [], { TERM: "xterm-256color" }]);
+    const pid = resp.value;
     const ch = resp.channel;
     //parent.wanix.termCh = ch;
     
@@ -69,7 +70,7 @@
       ch.write(enc.encode(data));
     });
     terminal.onResize((size) => {
-      //wanix.call("terminal.Resize", [{ Rows: size.rows, Cols: size.cols }]);
+      sys.call("tty.resize", [pid, size.rows, size.cols]);
     })
     terminal.attachCustomKeyEventHandler((e) => {
       // if (visorKeydown(e)) {

--- a/kernel/proc/js.go
+++ b/kernel/proc/js.go
@@ -37,7 +37,7 @@ func (s *Service) spawn(this js.Value, args []js.Value) any {
 			jsutil.Err(err)
 			return nil, err
 		}
-		return p.PID, nil
+		return p.ID, nil
 	})
 }
 

--- a/kernel/proc/proc.go
+++ b/kernel/proc/proc.go
@@ -43,7 +43,7 @@ func (s *Service) Spawn(path string, args []string, env map[string]string, dir s
 	s.mu.Lock()
 	s.nextPID++
 	p := &Process{
-		PID:  s.nextPID,
+		ID:   s.nextPID,
 		Path: path,
 		Args: args,
 		Env:  env,
@@ -52,7 +52,7 @@ func (s *Service) Spawn(path string, args []string, env map[string]string, dir s
 	s.running[s.nextPID] = p
 	s.mu.Unlock()
 
-	p.Task = js.Global().Get("task").Get("Task").New(js.Global().Get("initfs"), p.PID)
+	p.Task = js.Global().Get("task").Get("Task").New(js.Global().Get("initfs"), p.ID)
 	_, err := jsutil.AwaitErr(p.Task.Call("exec", p.Path, jsutil.ToJSArray(p.Args), map[string]any{
 		"env": jsutil.ToJSMap(p.Env),
 		"dir": p.Dir,
@@ -65,7 +65,7 @@ func (s *Service) Spawn(path string, args []string, env map[string]string, dir s
 }
 
 type Process struct {
-	PID  int
+	ID   int
 	Task js.Value
 
 	Path string

--- a/kernel/tty/js.go
+++ b/kernel/tty/js.go
@@ -13,11 +13,23 @@ func (s *Service) InitializeJS() {
 		"open": map[string]any{
 			"respondRPC": js.FuncOf(s.open),
 		},
+		"resize": js.FuncOf(s.resize),
 	})
-	// expose to task host
+	// expose to task host and app frames
 	js.Global().Get("sys").Call("handle", "tty.open", map[string]any{
 		"respondRPC": js.FuncOf(s.open),
 	})
+	js.Global().Get("sys").Call("handle", "tty.resize", js.Global().Get("duplex").Call("handlerFrom", js.FuncOf(s.resize)))
+}
+
+func (s *Service) resize(this js.Value, jsArgs []js.Value) any {
+	var (
+		pid  = jsArgs[0].Int()
+		rows = jsArgs[1].Int()
+		cols = jsArgs[2].Int()
+	)
+	s.Resize(pid, rows, cols)
+	return nil
 }
 
 func (s *Service) open(this js.Value, jsArgs []js.Value) any {
@@ -33,12 +45,12 @@ func (s *Service) open(this js.Value, jsArgs []js.Value) any {
 			// todo: env, dir, rows, cols, term
 		)
 
-		p, tty, err := s.Open(path, args)
+		p, tty, err := s.Open(path, args, nil)
 		if err != nil {
 			responder.Call("return", jsutil.ToJSError(err))
 			return nil, err
 		}
-		ch := jsutil.Await(responder.Call("continue"))
+		ch := jsutil.Await(responder.Call("continue", p.ID))
 		go func() {
 			io.Copy(&jsutil.Writer{ch}, tty)
 		}()


### PR DESCRIPTION
add resize syscall, but only impacts new processes. include ROWS, COLS, and TERM env vars. this should be enough for getting programs like micro to start, but to actually resize the terminal while running will require a solution for signals.

closes #36 for purposes of unblocking #6 