### PR TITLE
`watch` syscall and `open` command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/evanw/esbuild v0.19.5
 	github.com/spf13/afero v1.10.0
 	golang.org/x/term v0.13.0
-	tractor.dev/toolkit-go v0.0.0-20231108030452-f76673e11cd3
+	tractor.dev/toolkit-go v0.0.0-20231221004400-0208bc4b870f
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -447,3 +447,5 @@ rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 tractor.dev/toolkit-go v0.0.0-20231108030452-f76673e11cd3 h1:RZ6kq7stc3gPEljEhmbgB7uLQd1xRz2JA68a/HA+6p0=
 tractor.dev/toolkit-go v0.0.0-20231108030452-f76673e11cd3/go.mod h1:gteH4mWzJV+Y5zk6/Q6rPuWeOCFHnr55XPTgYEHuzUo=
+tractor.dev/toolkit-go v0.0.0-20231221004400-0208bc4b870f h1:knfelP7vT8rbuLgvKd94vSdC70PbjxsumcQZKDOQOIg=
+tractor.dev/toolkit-go v0.0.0-20231221004400-0208bc4b870f/go.mod h1:gteH4mWzJV+Y5zk6/Q6rPuWeOCFHnr55XPTgYEHuzUo=

--- a/internal/indexedfs/indexedfs.go
+++ b/internal/indexedfs/indexedfs.go
@@ -49,12 +49,16 @@ func (ifs *FS) Chmod(name string, mode fs.FileMode) error {
 	updateFunc := js.FuncOf(func(this js.Value, args []js.Value) any {
 		file := args[0]
 		file.Set("perms", uint32(mode.Perm()))
+		file.Set("ctime", time.Now().Unix())
 		return file
 	})
 	defer updateFunc.Release()
 
-	_, err := jsutil.AwaitErr(callHelper("updateFile", ifs.db, name, updateFunc))
-	return err
+	if _, err := jsutil.AwaitErr(callHelper("updateFile", ifs.db, name, updateFunc)); err != nil {
+		return &fs.PathError{Op: "chmod", Path: name, Err: err}
+	}
+
+	return nil
 }
 func (ifs *FS) Chown(name string, uid, gid int) error {
 	return fs.ErrPermission // TODO: maybe just a no-op?
@@ -68,12 +72,16 @@ func (ifs *FS) Chtimes(name string, atime time.Time, mtime time.Time) error {
 		file := args[0]
 		file.Set("atime", atime.Unix())
 		file.Set("mtime", mtime.Unix())
+		file.Set("ctime", time.Now().Unix())
 		return file
 	})
 	defer updateFunc.Release()
 
-	_, err := jsutil.AwaitErr(callHelper("updateFile", ifs.db, name, updateFunc))
-	return err
+	if _, err := jsutil.AwaitErr(callHelper("updateFile", ifs.db, name, updateFunc)); err != nil {
+		return &fs.PathError{Op: "chtimes", Path: name, Err: err}
+	}
+
+	return nil
 }
 func (ifs *FS) Create(name string) (fs.File, error) {
 	return ifs.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
@@ -86,14 +94,19 @@ func (ifs *FS) Mkdir(name string, perm fs.FileMode) error {
 	if dir != "." && dir != "/" {
 		exists, err := fs.DirExists(ifs, dir)
 		if err != nil {
-			return err
+			return &fs.PathError{Op: "mkdir", Path: name, Err: err}
 		}
 		if !exists {
 			return &fs.PathError{Op: "mkdir", Path: dir, Err: fs.ErrInvalid}
 		}
 	}
-	_, err := jsutil.AwaitErr(callHelper("addFile", ifs.db, name, uint32(perm), true))
-	return err
+
+	_, err := jsutil.AwaitErr(callHelper("addFile", ifs.db, name, uint32(perm), true, time.Now().Unix()))
+	if err != nil {
+		return &fs.PathError{Op: "mkdir", Path: name, Err: err}
+	}
+
+	return nil
 }
 func (ifs *FS) MkdirAll(path string, perm fs.FileMode) error {
 	if !fs.ValidPath(path) {
@@ -109,11 +122,11 @@ func (ifs *FS) MkdirAll(path string, perm fs.FileMode) error {
 		dir := filepath.Join(pp...)
 		exists, err := fs.DirExists(ifs, dir)
 		if err != nil {
-			return err
+			return &fs.PathError{Op: "mkdirall", Path: dir, Err: err}
 		}
 		if !exists {
 			if err := ifs.Mkdir(dir, perm); err != nil {
-				return err
+				return &fs.PathError{Op: "mkdirall", Path: dir, Err: err}
 			}
 		}
 	}
@@ -152,21 +165,22 @@ func (ifs *FS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error
 		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrExist}
 	}
 
-	// TODO: figure out a better way of signaling error type from javascript
-	if err != nil && strings.Contains(err.Error(), "ErrNotExist") {
-		if flag&os.O_CREATE > 0 {
-			if key, err = jsutil.AwaitErr(callHelper("addFile", ifs.db, name, uint32(perm), perm.IsDir())); err == nil {
+	if err != nil {
+		// TODO: figure out a better way of signaling error type from javascript
+		if strings.Contains(err.Error(), "ErrNotExist") {
+			if flag&os.O_CREATE > 0 {
+				key, err = jsutil.AwaitErr(callHelper("addFile", ifs.db, name, uint32(perm), perm.IsDir(), time.Now().Unix()))
+				if err != nil {
+					return nil, &fs.PathError{Op: "open", Path: name, Err: err}
+				}
+
 				file = &indexedFile{name: name, key: key.Int(), ifs: ifs, flags: flag}
 			} else {
-				return nil, &fs.PathError{Op: "open", Path: name, Err: err}
+				return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
 			}
 		} else {
-			return nil, fs.ErrNotExist
+			return nil, &fs.PathError{Op: "open", Path: name, Err: err}
 		}
-	}
-
-	if err != nil {
-		return nil, &fs.PathError{Op: "open", Path: name, Err: err}
 	}
 
 	if flag&os.O_APPEND > 0 {
@@ -175,6 +189,20 @@ func (ifs *FS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error
 	if flag&os.O_TRUNC > 0 {
 		// TODO: proper Truncate implementation
 		file.(*indexedFile).Seek(0, io.SeekStart)
+	}
+
+	// if we didn't just create the file, update atime
+	if flag&os.O_CREATE == 0 {
+		updateFunc := js.FuncOf(func(this js.Value, args []js.Value) any {
+			file := args[0]
+			file.Set("atime", time.Now().Unix())
+			return file
+		})
+		defer updateFunc.Release()
+
+		if _, err = jsutil.AwaitErr(callHelper("updateFile", ifs.db, name, updateFunc)); err != nil {
+			return nil, &fs.PathError{Op: "open", Path: name, Err: err}
+		}
 	}
 
 	return file, nil
@@ -186,18 +214,23 @@ func (ifs *FS) Remove(name string) error {
 	}
 	key, err := jsutil.AwaitErr(callHelper("getFileKey", ifs.db, name))
 	if err != nil {
-		return err
+		return &fs.PathError{Op: "remove", Path: name, Err: err}
 	}
-	_, err = jsutil.AwaitErr(callHelper("deleteFile", ifs.db, key))
-	return err
+	if _, err = jsutil.AwaitErr(callHelper("deleteFile", ifs.db, key)); err != nil {
+		return &fs.PathError{Op: "remove", Path: name, Err: err}
+	}
+
+	return nil
 }
 
 func (ifs *FS) RemoveAll(path string) error {
 	if !fs.ValidPath(path) {
 		return &fs.PathError{Op: "removeAll", Path: path, Err: fs.ErrInvalid}
 	}
-	_, err := jsutil.AwaitErr(callHelper("deleteAll", ifs.db, path))
-	return err
+	if _, err := jsutil.AwaitErr(callHelper("deleteAll", ifs.db, path)); err != nil {
+		return &fs.PathError{Op: "removeAll", Path: path, Err: err}
+	}
+	return nil
 }
 
 func (ifs *FS) Rename(oldname, newname string) error {
@@ -210,19 +243,22 @@ func (ifs *FS) Rename(oldname, newname string) error {
 
 	key, err := jsutil.AwaitErr(callHelper("getFileKey", ifs.db, oldname))
 	if err != nil {
-		return err
+		return &fs.PathError{Op: "rename", Path: newname, Err: err}
 	}
 
 	updateFunc := js.FuncOf(func(this js.Value, args []js.Value) any {
 		file := args[0]
 		file.Set("path", newname)
-		// TODO: set mtime
+		file.Set("ctime", time.Now().Unix())
 		return file
 	})
 	defer updateFunc.Release()
 
-	_, err = jsutil.AwaitErr(callHelper("updateFile", ifs.db, key, updateFunc))
-	return err
+	if _, err = jsutil.AwaitErr(callHelper("updateFile", ifs.db, key, updateFunc)); err != nil {
+		return &fs.PathError{Op: "rename", Path: newname, Err: err}
+	}
+
+	return nil
 }
 
 func (ifs *FS) Stat(name string) (fs.FileInfo, error) {
@@ -232,7 +268,7 @@ func (ifs *FS) Stat(name string) (fs.FileInfo, error) {
 
 	f, err := jsutil.AwaitErr(callHelper("getFileByPath", ifs.db, name))
 	if err != nil {
-		return nil, fs.ErrNotExist
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrNotExist}
 	}
 
 	return &indexedInfo{
@@ -272,7 +308,7 @@ type indexedFile struct {
 	flags  int
 	offset int64
 	// TODO: see if read/write caches can be merged
-	// used internally by data()
+	// used internally by getData()
 	readCache    []byte
 	outdatedRead bool
 	// used internally by Write() and Sync()
@@ -284,8 +320,10 @@ func (f *indexedFile) ReadDir(n int) ([]fs.DirEntry, error) {
 	return f.ifs.ReadDir(f.name)
 }
 
-func (f *indexedFile) data() ([]byte, error) {
+func (f *indexedFile) getData() ([]byte, error) {
 	if f.outdatedRead || f.readCache == nil {
+		// Deliberately not updating atime, as that can get slow fast.
+		// Aiming for posix-like, not compliant.
 		data, err := jsutil.AwaitErr(callHelper("readFile", f.ifs.db, f.key))
 		if err != nil {
 			return nil, err
@@ -321,7 +359,7 @@ func (f *indexedFile) Read(p []byte) (n int, err error) {
 		return 0, fs.ErrPermission
 	}
 
-	data, err := f.data()
+	data, err := f.getData()
 	if err != nil {
 		return 0, err
 	}
@@ -344,7 +382,7 @@ func (f *indexedFile) Read(p []byte) (n int, err error) {
 
 func (f *indexedFile) Write(p []byte) (n int, err error) {
 	if f.writeCache == nil {
-		if f.writeCache, err = f.data(); err != nil {
+		if f.writeCache, err = f.getData(); err != nil {
 			return 0, err
 		}
 	}
@@ -384,14 +422,17 @@ func (f *indexedFile) Sync() error {
 		js.CopyBytesToJS(buf, f.writeCache)
 		file.Set("blob", js.Global().Get("Blob").New([]any{buf}, mime))
 		file.Set("size", len(f.writeCache))
-		// TODO: set mtime
+
+		file.Set("mtime", time.Now().Unix())
+		file.Set("ctime", time.Now().Unix())
+		file.Set("atime", time.Now().Unix())
 		return file
 	})
 	defer updateFunc.Release()
 
 	_, err := jsutil.AwaitErr(callHelper("updateFile", f.ifs.db, f.key, updateFunc))
 	if err != nil {
-		return err
+		return &fs.PathError{Op: "sync", Path: f.name, Err: err}
 	}
 
 	f.dirty = false
@@ -412,15 +453,15 @@ func (f *indexedFile) Seek(offset int64, whence int) (int64, error) {
 	case io.SeekCurrent:
 		f.offset += offset
 	case io.SeekEnd:
-		if d, err := f.data(); err == nil {
+		if d, err := f.getData(); err == nil {
 			f.offset = int64(len(d)) + offset
 		} else {
-			return 0, err
+			return 0, &fs.PathError{Op: "seek", Path: f.name, Err: err}
 		}
 	}
 	if f.offset < 0 {
 		f.offset = 0
-		return 0, fmt.Errorf("Seek: resultant offset cannot be negative")
+		return 0, &fs.PathError{Op: "seek", Path: f.name, Err: fmt.Errorf("%w: resultant offset cannot be negative", fs.ErrInvalid)}
 	}
 	return f.offset, nil
 }

--- a/internal/indexedfs/indexedfs.js
+++ b/internal/indexedfs/indexedfs.js
@@ -55,7 +55,7 @@ export function initialize() {
 	})
 }
 
-export function addFile(db, path, perms, isdir) {
+export function addFile(db, path, perms, isdir, unixTime) {
 	return new Promise((resolve, reject) => {
 		const transaction = db.transaction("files", "readwrite");
 
@@ -70,9 +70,9 @@ export function addFile(db, path, perms, isdir) {
 			perms: perms,
 			size: 0,
 			isdir: isdir,
-			ctime: 0,
-			mtime: 0,
-			atime: 0,
+			ctime: unixTime,
+			mtime: unixTime,
+			atime: unixTime,
 			blob: new Blob([""], {
 				type: "text/plain"
 			}),

--- a/internal/osfs/osfs.go
+++ b/internal/osfs/osfs.go
@@ -3,6 +3,7 @@ package osfs
 
 import (
 	"os"
+	"path/filepath"
 	"time"
 
 	"tractor.dev/toolkit-go/engine/fs"
@@ -10,14 +11,12 @@ import (
 
 type FS struct{}
 
-// This file system is a passthrough for `os` calls, which expect rooted paths.
-// Pass OS paths, not io/fs paths.
 func New() *FS {
 	return &FS{}
 }
 
 func (FS) Create(name string) (fs.File, error) {
-	f, e := os.Create(name)
+	f, e := os.Create(fsToUnixPath(name))
 	if f == nil {
 		// while this looks strange, we need to return a bare nil (of type nil) not
 		// a nil value of type *os.File or nil won't be nil
@@ -27,7 +26,7 @@ func (FS) Create(name string) (fs.File, error) {
 }
 
 func (FS) Mkdir(name string, perm fs.FileMode) error {
-	return os.Mkdir(name, perm)
+	return os.Mkdir(fsToUnixPath(name), perm)
 }
 
 func (FS) MkdirAll(path string, perm fs.FileMode) error {
@@ -35,7 +34,7 @@ func (FS) MkdirAll(path string, perm fs.FileMode) error {
 }
 
 func (FS) Open(name string) (fs.File, error) {
-	f, e := os.Open(name)
+	f, e := os.Open(fsToUnixPath(name))
 	if f == nil {
 		// while this looks strange, we need to return a bare nil (of type nil) not
 		// a nil value of type *os.File or nil won't be nil
@@ -45,7 +44,7 @@ func (FS) Open(name string) (fs.File, error) {
 }
 
 func (FS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error) {
-	f, e := os.OpenFile(name, flag, perm)
+	f, e := os.OpenFile(fsToUnixPath(name), flag, perm)
 	if f == nil {
 		// while this looks strange, we need to return a bare nil (of type nil) not
 		// a nil value of type *os.File or nil won't be nil
@@ -55,29 +54,38 @@ func (FS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error) {
 }
 
 func (FS) Remove(name string) error {
-	return os.Remove(name)
+	return os.Remove(fsToUnixPath(name))
 }
 
 func (FS) RemoveAll(path string) error {
-	return os.RemoveAll(path)
+	return os.RemoveAll(fsToUnixPath(path))
 }
 
 func (FS) Rename(oldname, newname string) error {
-	return os.Rename(oldname, newname)
+	return os.Rename(fsToUnixPath(oldname), fsToUnixPath(newname))
 }
 
 func (FS) Stat(name string) (fs.FileInfo, error) {
-	return os.Stat(name)
+	return os.Stat(fsToUnixPath(name))
 }
 
 func (FS) Chmod(name string, mode fs.FileMode) error {
-	return os.Chmod(name, mode)
+	return os.Chmod(fsToUnixPath(name), mode)
 }
 
 func (FS) Chown(name string, uid, gid int) error {
-	return os.Chown(name, uid, gid)
+	return os.Chown(fsToUnixPath(name), uid, gid)
 }
 
 func (FS) Chtimes(name string, atime time.Time, mtime time.Time) error {
-	return os.Chtimes(name, atime, mtime)
+	return os.Chtimes(fsToUnixPath(name), atime, mtime)
+}
+
+// Converts an `io/fs` path to a Unix path.
+// Assumes path is absolute already
+func fsToUnixPath(path string) string {
+	if !filepath.IsAbs(path) {
+		path = "/" + path
+	}
+	return filepath.Clean(path)
 }

--- a/kernel/fs/fs.go
+++ b/kernel/fs/fs.go
@@ -30,9 +30,6 @@ type Service struct {
 	fds    map[int]*fd
 	nextFd int
 
-	watches         map[int]*watchfs.Watch
-	nextWatchHandle int
-
 	mu sync.Mutex
 }
 
@@ -44,8 +41,6 @@ type fd struct {
 func (s *Service) Initialize() {
 	s.fds = make(map[int]*fd)
 	s.nextFd = 1000
-	s.watches = make(map[int]*watchfs.Watch)
-	s.nextWatchHandle = 0
 
 	ifs, err := indexedfs.New()
 	if err != nil {
@@ -95,8 +90,10 @@ func (s *Service) InitializeJS() {
 	fsObj.Set("unlink", js.FuncOf(s.unlink))
 	fsObj.Set("fsync", js.FuncOf(s.fsync))
 	fsObj.Set("utimes", js.FuncOf(s.utimes))
-	fsObj.Set("watch", js.FuncOf(s.watchEvented))
-	fsObj.Set("unwatch", js.FuncOf(s.unwatch))
+
+	js.Global().Get("api").Get("fs").Set("watch", map[string]any{
+		"respondRPC": js.FuncOf(s.watchRPC),
+	})
 
 	// TODO later
 	// ftruncate(fd, length, callback) { callback(enosys()); },
@@ -678,17 +675,22 @@ func (s *Service) utimes(this js.Value, args []js.Value) any {
 	return nil
 }
 
-// watch(path, recursive, eventMask, ignores, eventCallback, callback)
-func (s *Service) watchEvented(this js.Value, args []js.Value) any {
+// watch(path, recursive, eventMask, ignores)
+func (s *Service) watchRPC(this js.Value, args []js.Value) any {
 	var (
-		path      = cleanPath(args[0].String())
-		recursive = args[1].Bool()
-		eventMask = uint(args[2].Int())
-		ignores   = jsutil.ToGoStringSlice(args[3])
-		eventCb   = args[4]
-		cb        = args[5]
+		response = args[0]
+		call     = args[1]
 	)
-	go func() {
+
+	return jsutil.Promise(func() (any, error) {
+		params := jsutil.Await(call.Call("receive"))
+		var (
+			path      = cleanPath(params.Index(0).String())
+			recursive = params.Index(1).Bool()
+			eventMask = uint(params.Index(2).Int())
+			ignores   = jsutil.ToGoStringSlice(params.Index(3))
+		)
+
 		log("watch", path)
 
 		w, err := s.fsys.Watch(path, &watchfs.Config{
@@ -706,38 +708,18 @@ func (s *Service) watchEvented(this js.Value, args []js.Value) any {
 					"oldpath": e.OldPath,
 					"err":     jsErr,
 				}
-				eventCb.Invoke(jsEvent)
+				response.Call("send", jsEvent)
 			},
 		})
 		if err != nil {
-			cb.Invoke(nil, jsutil.ToJSError(err))
-			return
+			response.Call("return", jsutil.ToJSError(err))
+			return nil, err
 		}
 
-		wHandle := s.nextWatchHandle
-		s.watches[wHandle] = w
-		s.nextWatchHandle++
-		cb.Invoke(wHandle, nil)
-	}()
-
-	return nil
-}
-
-// unwatch(handle, callback)
-func (s *Service) unwatch(this js.Value, args []js.Value) any {
-	var (
-		handle = args[0].Int()
-		cb     = args[1]
-	)
-
-	w, exists := s.watches[handle]
-	if !exists {
-		cb.Invoke(jsutil.ToJSError(fs.ErrClosed))
-		return nil
-	}
-
-	w.Close()
-	delete(s.watches, handle)
-	cb.Invoke(nil)
-	return nil
+		ch := jsutil.Await(response.Call("continue"))
+		io.CopyN(io.Discard, &jsutil.Reader{ch}, 1) // read blocks close
+		ch.Call("close")
+		w.Close()
+		return nil, nil
+	})
 }

--- a/kernel/fs/fs.go
+++ b/kernel/fs/fs.go
@@ -691,7 +691,7 @@ func (s *Service) watchRPC(this js.Value, args []js.Value) any {
 			ignores   = jsutil.ToGoStringSlice(params.Index(3))
 		)
 
-		log("watch", path)
+		log("watch", path, recursive, eventMask, params.Index(3))
 
 		w, err := s.fsys.Watch(path, &watchfs.Config{
 			Recursive: recursive,

--- a/kernel/web/lib/syscall.js
+++ b/kernel/web/lib/syscall.js
@@ -103,12 +103,6 @@ globalThis.api = {
     utimes(path, atime, mtime) { 
       return new Promise((ok, err) => globalThis.fs.utimes(path, atime, mtime, cb(ok, err)));
     },
-    watch(path, recursive, eventMask, ignores, eventCallback) { 
-      return new Promise((ok, err) => globalThis.fs.watch(path, recursive, eventMask, ignores, eventCallback, cb(ok, err)));
-    },
-    unwatch(handle) { 
-      return new Promise((ok, err) => globalThis.fs.unwatch(handle, cb(err)));
-    },
   }
 }
 

--- a/kernel/web/lib/syscall.js
+++ b/kernel/web/lib/syscall.js
@@ -103,6 +103,12 @@ globalThis.api = {
     utimes(path, atime, mtime) { 
       return new Promise((ok, err) => globalThis.fs.utimes(path, atime, mtime, cb(ok, err)));
     },
+    watch(path, recursive, eventMask, ignores, eventCallback) { 
+      return new Promise((ok, err) => globalThis.fs.watch(path, recursive, eventMask, ignores, eventCallback, cb(ok, err)));
+    },
+    unwatch(handle) { 
+      return new Promise((ok, err) => globalThis.fs.unwatch(handle, cb(err)));
+    },
   }
 }
 

--- a/kernel/web/lib/syscall.js
+++ b/kernel/web/lib/syscall.js
@@ -103,12 +103,6 @@ globalThis.api = {
     utimes(path, atime, mtime) { 
       return new Promise((ok, err) => globalThis.fs.utimes(path, atime, mtime, cb(ok, err)));
     },
-    watch(path, recursive, eventMask, ignores) {
-      return new Promise((ok, err) => globalThis.fs.watch(path, recursive, eventMask, ignores, cb(ok, err)));
-    },
-    unwatch(handle) {
-      return new Promise((ok, err) => globalThis.fs.unwatch(handle, cb(ok, err)))
-    }
   }
 }
 

--- a/kernel/web/lib/syscall.js
+++ b/kernel/web/lib/syscall.js
@@ -103,6 +103,12 @@ globalThis.api = {
     utimes(path, atime, mtime) { 
       return new Promise((ok, err) => globalThis.fs.utimes(path, atime, mtime, cb(ok, err)));
     },
+    watch(path, recursive, eventMask, ignores) {
+      return new Promise((ok, err) => globalThis.fs.watch(path, recursive, eventMask, ignores, cb(ok, err)));
+    },
+    unwatch(handle) {
+      return new Promise((ok, err) => globalThis.fs.unwatch(handle, cb(ok, err)))
+    }
   }
 }
 

--- a/shell/copy.go
+++ b/shell/copy.go
@@ -60,7 +60,7 @@ Omits any SOURCE that is a directory if "-r" flag isn't specified.
 				var finalDestExists bool
 				if DEST_isDir {
 					finalDest = filepath.Join(DEST, filepath.Base(SOURCE))
-					finalDestExists, err = fs.Exists(osfs.New(), finalDest)
+					finalDestExists, err = fs.Exists(osfs.New(), unixToFsPath(finalDest))
 					if checkErr(ctx, err) {
 						continue
 					}
@@ -94,7 +94,7 @@ Omits any SOURCE that is a directory if "-r" flag isn't specified.
 					}
 				}
 
-				if err := fsutil.CopyAll(osfs.New(), SOURCE, finalDest); checkErr(ctx, err) {
+				if err := fsutil.CopyAll(osfs.New(), unixToFsPath(SOURCE), unixToFsPath(finalDest)); checkErr(ctx, err) {
 					return
 				}
 			}

--- a/shell/copy.go
+++ b/shell/copy.go
@@ -38,7 +38,6 @@ Omits any SOURCE that is a directory if "-r" flag isn't specified.
 			DEST_exists := dstErr == nil
 			DEST_isDir := DEST_exists && dstInfo.IsDir()
 
-			fmt.Println(args)
 			if len(args)-1 >= 2 && !DEST_isDir {
 				io.WriteString(ctx, fmt.Sprintf("target '%s' is not a directory\n", args[len(args)-1]))
 				return

--- a/shell/main.go
+++ b/shell/main.go
@@ -58,6 +58,8 @@ func (m *Shell) buildCmds() {
 	m.cmd.AddCommand(printEnvCmd())
 	m.cmd.AddCommand(exportCmd())
 	m.cmd.AddCommand(treeCmd())
+	m.cmd.AddCommand(watchCmd())
+	m.cmd.AddCommand(unwatchCmd())
 	m.cmd.Run = m.ExecuteCommand
 }
 

--- a/shell/smallcmds.go
+++ b/shell/smallcmds.go
@@ -39,12 +39,12 @@ func mtimeCmd() *cli.Command {
 		Usage: "mtime <path>",
 		Args:  cli.ExactArgs(1),
 		Run: func(ctx *cli.Context, args []string) {
-			fi, err := os.Stat(args[0])
+			fi, err := os.Stat(absPath(args[0]))
 			if err != nil {
-				fmt.Fprintf(ctx, "%s\n", err)
+				fmt.Fprintln(ctx, err)
 				return
 			}
-			fmt.Fprintf(ctx, "%s\n", fi.ModTime())
+			fmt.Fprintln(ctx, fi.ModTime())
 		},
 	}
 	return cmd

--- a/shell/watch.go
+++ b/shell/watch.go
@@ -69,7 +69,7 @@ func unwatchCmd() *cli.Command {
 				fmt.Printf("path '%s' isn't being watched\n", absPath(path))
 				return
 			}
-			// this should close the rpc channel
+			// close the rpc channel
 			jsutil.Await(resp.Call("send", 0))
 			delete(watches, path)
 		},

--- a/shell/watch.go
+++ b/shell/watch.go
@@ -19,7 +19,7 @@ func watchCmd() *cli.Command {
 		Usage: "watch [-recursive] <path>",
 		Args:  cli.MinArgs(1),
 		Run: func(ctx *cli.Context, args []string) {
-			path := absPath(args[0])
+			path := unixToFsPath(args[0])
 
 			if watcher == nil {
 				watcher = watchfs.New(osfs.New())
@@ -27,13 +27,13 @@ func watchCmd() *cli.Command {
 
 			if exists, err := fs.Exists(watcher, path); !exists {
 				if !checkErr(ctx, err) {
-					fmt.Printf("file or directory at path '%s' doesn't exist\n", path)
+					fmt.Printf("file or directory at path '%s' doesn't exist\n", absPath(path))
 				}
 				return
 			}
 
 			if _, exists := watches[path]; exists {
-				fmt.Printf("path '%s' is already being watched\n", path)
+				fmt.Printf("path '%s' is already being watched\n", absPath(path))
 				return
 			}
 
@@ -60,10 +60,10 @@ func unwatchCmd() *cli.Command {
 		Usage: "unwatch <path>", // todo add -r
 		Args:  cli.ExactArgs(1),
 		Run: func(ctx *cli.Context, args []string) {
-			path := absPath(args[0])
+			path := unixToFsPath(args[0])
 			w, exists := watches[path]
 			if !exists {
-				fmt.Printf("path '%s' isn't being watched\n", path)
+				fmt.Printf("path '%s' isn't being watched\n", absPath(path))
 				return
 			}
 			w.Close()


### PR DESCRIPTION
Closes #38

- Implemented `watch` syscall using RPC, since we need to send structured data to/from the kernel process.
- Added `Watch` support to `mountablefs`.
- Converted `osfs` to use `io/fs` paths instead of Unix ones, for better compatibility with other file systems.
- Implemented `open`, `watch`, and `unwatch` shell commands
