### PR TITLE
Exportapp and compiling build tool from source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .DS_Store
 external/jazz/node_modules
 /local
+/build/pkg.zip

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ shell: shell/main.go local/bin
 	cd shell && GOOS=js GOARCH=wasm go build -o ../local/bin/shell .
 
 build: build/main.go build/pkg.zip local/bin
+	cd build && go run ./build-pkgs/main.go ./build-pkgs/imports ./pkg2
 	cd build && GOOS=js GOARCH=wasm go build -o ../local/bin/build .
 
 local/bin:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ shell: shell/main.go local/bin
 	cd shell && GOOS=js GOARCH=wasm go build -o ../local/bin/shell .
 
 build/pkg.zip: build/build-pkgs/imports/imports.go build/build-pkgs/main.go
-	cd build && go run ./build-pkgs/main.go ./build-pkgs/imports ./pkg3
+	cd build && go run ./build-pkgs/main.go ./build-pkgs/imports ./pkg.zip
 
 build: build/main.go build/pkg.zip local/bin
 	cd build && GOOS=js GOARCH=wasm go build -o ../local/bin/build .

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,10 @@ kernel: kernel/main.go local/bin
 shell: shell/main.go local/bin
 	cd shell && GOOS=js GOARCH=wasm go build -o ../local/bin/shell .
 
+build/pkg.zip: build/build-pkgs/imports/imports.go build/build-pkgs/main.go
+	cd build && go run ./build-pkgs/main.go ./build-pkgs/imports ./pkg3
+
 build: build/main.go build/pkg.zip local/bin
-	cd build && go run ./build-pkgs/main.go ./build-pkgs/imports ./pkg2
 	cd build && GOOS=js GOARCH=wasm go build -o ../local/bin/build .
 
 local/bin:

--- a/build/build-pkgs/imports/go.mod
+++ b/build/build-pkgs/imports/go.mod
@@ -1,0 +1,13 @@
+module build-pkgs/imports
+
+go 1.21.1
+
+require (
+	github.com/evanw/esbuild v0.19.11
+	tractor.dev/toolkit-go v0.0.0-20231221004400-0208bc4b870f
+)
+
+require (
+	golang.org/x/sys v0.5.0 // indirect
+	golang.org/x/text v0.13.0 // indirect
+)

--- a/build/build-pkgs/imports/go.sum
+++ b/build/build-pkgs/imports/go.sum
@@ -1,0 +1,17 @@
+github.com/evanw/esbuild v0.19.11 h1:mbPO1VJ/df//jjUd+p/nRLYCpizXxXb2w/zZMShxa2k=
+github.com/evanw/esbuild v0.19.11/go.mod h1:D2vIQZqV/vIf/VRHtViaUtViZmG7o+kKmlBfVQuRi48=
+github.com/fxamacker/cbor/v2 v2.5.0 h1:oHsG0V/Q6E/wqTS2O1Cozzsy69nqCiguo5Q1a1ADivE=
+github.com/fxamacker/cbor/v2 v2.5.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
+golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
+golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
+golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
+tractor.dev/toolkit-go v0.0.0-20231221004400-0208bc4b870f h1:knfelP7vT8rbuLgvKd94vSdC70PbjxsumcQZKDOQOIg=
+tractor.dev/toolkit-go v0.0.0-20231221004400-0208bc4b870f/go.mod h1:gteH4mWzJV+Y5zk6/Q6rPuWeOCFHnr55XPTgYEHuzUo=

--- a/build/build-pkgs/imports/imports.go
+++ b/build/build-pkgs/imports/imports.go
@@ -1,0 +1,24 @@
+package imports
+
+import (
+	"embed"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/evanw/esbuild/pkg/api"
+	"tractor.dev/toolkit-go/engine"
+	"tractor.dev/toolkit-go/engine/cli"
+	"tractor.dev/toolkit-go/engine/daemon"
+	"tractor.dev/toolkit-go/engine/fs"
+	"tractor.dev/toolkit-go/engine/fs/makefs"
+	"tractor.dev/toolkit-go/engine/fs/memfs"
+	"tractor.dev/toolkit-go/engine/fs/mountablefs"
+	"tractor.dev/toolkit-go/engine/fs/mountfs"
+	"tractor.dev/toolkit-go/engine/fs/readonlyfs"
+	"tractor.dev/toolkit-go/engine/fs/watchfs"
+	"tractor.dev/toolkit-go/engine/fs/workingpathfs"
+	"tractor.dev/toolkit-go/engine/fs/xformfs"
+)

--- a/build/build-pkgs/main.go
+++ b/build/build-pkgs/main.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+func main() {
+	importsDir, err := filepath.Abs(os.Args[1])
+	if err != nil {
+		fatal(err.Error())
+	}
+	pkgStagingDir, err := filepath.Abs(os.Args[2])
+	if err != nil {
+		fatal(err.Error())
+	}
+
+	buildArchives(pkgStagingDir, importsDir, "js", "wasm")
+	buildArchives(pkgStagingDir, importsDir, "darwin", "amd64")
+
+	if err := os.Chdir(pkgStagingDir); err != nil {
+		fatal(err.Error())
+	}
+
+	// TODO: build importcfg_target.link files
+
+	// TODO: build compile.wasm and link.wasm
+}
+
+func buildArchives(workingDir, importsDir, GOOS, GOARCH string) {
+	if err := os.Chdir(importsDir); err != nil {
+		fatal(err.Error())
+	}
+
+	cmd := exec.Command("go", "install", "-work", "-a", "-trimpath", "./...")
+	cmd.Env = append(os.Environ(), "GOOS="+GOOS, "GOARCH="+GOARCH)
+
+	fmt.Println(cmd.String())
+	output, err := cmd.CombinedOutput()
+
+	// Ignoring "imported but not used" errors.
+	// It should have compiled the archives anyway.
+	if err != nil && cmd.ProcessState.ExitCode() == 0 {
+		if output != nil {
+			fmt.Println(string(output))
+		}
+
+		fatal(err.Error())
+	}
+
+	rgx, err := regexp.Compile("WORK=(.*)")
+	if err != nil {
+		fatal(err.Error())
+	}
+
+	rgxMatches := rgx.FindSubmatch(output)
+	if rgxMatches == nil || rgxMatches[1] == nil {
+		fatal("install output missing WORK path")
+	}
+
+	WORK := string(rgxMatches[1])
+
+	fmt.Println("WORK:", WORK)
+	defer os.RemoveAll(WORK)
+
+	workFS := os.DirFS(WORK)
+	globMatches, err := fs.Glob(workFS, "*/importcfg")
+	if err != nil {
+		fatal(err.Error())
+	}
+
+	rgx, err = regexp.Compile("packagefile (.*)")
+	if err != nil {
+		fatal(err.Error())
+	}
+
+	outputDir := filepath.Join(workingDir, "targets", GOOS+"_"+GOARCH)
+	if err := os.MkdirAll(outputDir, 0655); err != nil {
+		fatal(err.Error())
+	}
+	for _, filename := range globMatches {
+		contents, err := fs.ReadFile(workFS, filename)
+		if err != nil {
+			fmt.Printf("skipping %s: %s\n", filename, err)
+			continue
+		}
+
+		pkgMatches := rgx.FindAllSubmatch(contents, -1)
+		if pkgMatches == nil {
+			// fmt.Printf("skipping %s: no packagefiles\n", filename)
+			continue
+		}
+
+		visited := map[string]struct{}{}
+		unique := []string{}
+		for _, m := range pkgMatches {
+			str := string(m[1])
+			if _, ok := visited[str]; !ok {
+				visited[str] = struct{}{}
+				unique = append(unique, str)
+			}
+		}
+
+		for _, pkg := range unique {
+			name, path, found := strings.Cut(pkg, "=")
+			if !found {
+				continue
+			}
+
+			newpath := filepath.Join(outputDir, name) + ".a"
+			if err = os.MkdirAll(filepath.Dir(newpath), 0655); err != nil {
+				fatal(err.Error())
+			}
+			if err = copyFile(path, newpath); err != nil {
+				fatal(err.Error())
+			}
+		}
+	}
+}
+
+func copyFile(srcPath, dstPath string) error {
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+
+	dst, err := os.Create(dstPath)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(dst, src)
+	return err
+}
+
+func fatal(msg string) {
+	fmt.Println(msg)
+	os.Exit(1)
+}

--- a/internal/export/exportapp.sh
+++ b/internal/export/exportapp.sh
@@ -1,5 +1,4 @@
-cp -r /app/$1 /sys/export
-mv /sys/export/$1 /sys/export/assets 
-GOOS=darwin GOARCH=amd64 build /sys/export/main.go
-mv /sys/export/export /sys/export/$1
+rm -r /sys/export/assets 
+cp -r /app/$1 /sys/export/assets 
+build -os $GOOS -arch $GOARCH -output /sys/export/$1 /sys/export/main.go
 dl /sys/export/$1

--- a/internal/export/main.go
+++ b/internal/export/main.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 
 	esbuild "github.com/evanw/esbuild/pkg/api"
-	"github.com/spf13/afero"
 	"tractor.dev/toolkit-go/engine/fs/xformfs"
 )
 
@@ -26,11 +25,11 @@ func main() {
 		if _, ok := ext[filepath.Ext(r.URL.Path)]; ok {
 			w.Header().Set("content-type", "text/javascript")
 		}
-		httpfs := xformfs.New(afero.FromIOFS{FS: assets})
-		httpfs.Transform(".jsx", transformJSX)
-		httpfs.Transform(".tsx", transformTSX)
-		httpfs.Transform(".ts", transformTSX)
-		http.FileServer(afero.NewHttpFs(httpfs).Dir("assets")).ServeHTTP(w, r)
+		xfs := xformfs.New(assets)
+		xfs.Transform(".jsx", transformJSX)
+		xfs.Transform(".tsx", transformTSX)
+		xfs.Transform(".ts", transformTSX)
+		http.FileServer(http.FS(xfs)).ServeHTTP(w, r)
 	}))
 	fmt.Println("Serving at http://localhost:7070/ ...")
 	http.ListenAndServe(":7070", nil)

--- a/internal/indexedfs/indexedfs.go
+++ b/internal/indexedfs/indexedfs.go
@@ -352,8 +352,8 @@ func (f *indexedFile) Write(p []byte) (n int, err error) {
 	writeEnd := f.offset + int64(len(p))
 
 	if writeEnd > int64(cap(f.writeCache)) {
-		newCapacity := cap(f.writeCache)*2 + 1
-		for ; writeEnd > int64(newCapacity); newCapacity *= 2 {
+		newCapacity := int64(cap(f.writeCache))*2 + 1
+		for ; writeEnd > newCapacity; newCapacity *= 2 {
 		}
 
 		newCache := make([]byte, len(f.writeCache), newCapacity)
@@ -363,6 +363,7 @@ func (f *indexedFile) Write(p []byte) (n int, err error) {
 
 	copy(f.writeCache[f.offset:writeEnd], p)
 	f.writeCache = f.writeCache[:writeEnd]
+	f.offset = writeEnd
 	f.dirty = true
 	return len(p), nil
 }

--- a/kernel/fs/fs.go
+++ b/kernel/fs/fs.go
@@ -52,12 +52,12 @@ func (s *Service) Initialize() {
 	s.fsys = watchfs.New(mntfs)
 
 	// ensure basic system tree exists
-	fs.MkdirAll(s.fsys, "app", 0755)
-	fs.MkdirAll(s.fsys, "cmd", 0755)
-	fs.MkdirAll(s.fsys, "sys/app", 0755)
-	fs.MkdirAll(s.fsys, "sys/bin", 0755)
-	fs.MkdirAll(s.fsys, "sys/cmd", 0755)
-	fs.MkdirAll(s.fsys, "sys/dev", 0755)
+	fs.MkdirAll(s.fsys.FS, "app", 0755)
+	fs.MkdirAll(s.fsys.FS, "cmd", 0755)
+	fs.MkdirAll(s.fsys.FS, "sys/app", 0755)
+	fs.MkdirAll(s.fsys.FS, "sys/bin", 0755)
+	fs.MkdirAll(s.fsys.FS, "sys/cmd", 0755)
+	fs.MkdirAll(s.fsys.FS, "sys/dev", 0755)
 
 	devURL := fmt.Sprintf("%ssys/dev", js.Global().Get("hostURL").String())
 	resp, err := http.DefaultClient.Get(devURL)
@@ -69,9 +69,6 @@ func (s *Service) Initialize() {
 			panic(err)
 		}
 	}
-
-	s.fsys.MkdirAll("cmd/sauce", 0755)
-	fsutil.WriteFile(s.fsys, "cmd/sauce/main.go", []byte("package main\nimport \"fmt\"\nfunc main() {\n\tfmt.Println(\"Hello World!\")\n}"), 0644)
 }
 
 func (s *Service) InitializeJS() {
@@ -301,7 +298,7 @@ func (s *Service) readdir(this js.Value, args []js.Value) any {
 	go func() {
 		log("readdir", path)
 
-		fi, err := fs.ReadDir(s.fsys, path)
+		fi, err := fs.ReadDir(s.fsys.FS, path)
 		if err != nil {
 			cb.Invoke(jsutil.ToJSError(err))
 			return

--- a/kernel/fs/fs.go
+++ b/kernel/fs/fs.go
@@ -14,7 +14,6 @@ import (
 
 	"tractor.dev/toolkit-go/engine/fs"
 
-	"tractor.dev/toolkit-go/engine/fs/fsutil"
 	"tractor.dev/toolkit-go/engine/fs/watchfs"
 	"tractor.dev/wanix/internal/httpfs"
 	"tractor.dev/wanix/internal/indexedfs"
@@ -58,6 +57,36 @@ func (s *Service) Initialize() {
 	fs.MkdirAll(s.fsys.FS, "sys/bin", 0755)
 	fs.MkdirAll(s.fsys.FS, "sys/cmd", 0755)
 	fs.MkdirAll(s.fsys.FS, "sys/dev", 0755)
+
+	// copy build binary into filesystem
+	{
+		var exists bool
+		fi, err := fs.Stat(s.fsys.FS, "sys/cmd/build.wasm")
+		if err == nil {
+			exists = true
+		} else if os.IsNotExist(err) {
+			exists = false
+		} else {
+			panic(err)
+		}
+
+		blob := js.Global().Get("initfs").Get("build")
+
+		if !exists || int64(blob.Get("size").Int()) != fi.Size() {
+			buffer, err := jsutil.AwaitErr(blob.Call("arrayBuffer"))
+			if err != nil {
+				panic(err)
+			}
+
+			// TODO: creating the file and applying the blob directly in indexedfs would be faster.
+			data := make([]byte, blob.Get("size").Int())
+			js.CopyBytesToGo(data, js.Global().Get("Uint8Array").New(buffer))
+			err = fs.WriteFile(s.fsys.FS, "sys/cmd/build.wasm", data, 0644)
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
 
 	devURL := fmt.Sprintf("%ssys/dev", js.Global().Get("hostURL").String())
 	resp, err := http.DefaultClient.Get(devURL)

--- a/shell/main.go
+++ b/shell/main.go
@@ -147,11 +147,7 @@ __\      /___|  (__)  |_|  |___\   |_(      )_/  /__\  \_
 }
 
 func (m *Shell) ExecuteCommand(ctx *cli.Context, args []string) {
-	env := make(map[string]string)
-	for _, kvp := range os.Environ() {
-		parts := strings.SplitN(kvp, "=", 2)
-		env[parts[0]] = parts[1]
-	}
+	env := os.Environ()
 
 	var err error
 	args, err = parseEnvArgs(args, env)
@@ -170,7 +166,7 @@ func (m *Shell) ExecuteCommand(ctx *cli.Context, args []string) {
 		return
 	}
 
-	cmd.Env = packEnv(env)
+	cmd.Env = env
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	wc := cmd.StdinPipe()

--- a/shell/smallcmds.go
+++ b/shell/smallcmds.go
@@ -39,12 +39,12 @@ func mtimeCmd() *cli.Command {
 		Usage: "mtime <path>",
 		Args:  cli.ExactArgs(1),
 		Run: func(ctx *cli.Context, args []string) {
-			fi, err := os.Stat(args[0])
+			fi, err := os.Stat(absPath(args[0]))
 			if err != nil {
-				fmt.Fprintf(ctx, "%s\n", err)
+				fmt.Fprintln(ctx, err)
 				return
 			}
-			fmt.Fprintf(ctx, "%s\n", fi.ModTime())
+			fmt.Fprintln(ctx, fi.ModTime())
 		},
 	}
 	return cmd

--- a/shell/util.go
+++ b/shell/util.go
@@ -54,30 +54,58 @@ func isWasmFile(name string) bool {
 	return bytes.Equal(magic, WASM_MAGIC)
 }
 
-func parseEnvArgs(args []string, env []string) (rest []string, err error) {
+func parsePrefixEnvArgs(args []string, env *[]string) (rest []string, err error) {
 	for i, arg := range args {
-		name, value, found := strings.Cut(arg, "=")
+		key, value, found := strings.Cut(arg, "=")
 		if !found {
 			rest = args[i:]
 			break
 		}
-		if name == "" {
+		if key == "" {
 			return rest, fmt.Errorf("invalid variable at arg %d", i)
 		}
 
 		found = false
-		for j, entry := range env {
-			if strings.HasPrefix(entry, name) {
-				env[j] = strings.Join([]string{name, value}, "=")
+		for j, entry := range *env {
+			if strings.HasPrefix(entry, key) {
+				(*env)[j] = strings.Join([]string{key, value}, "=")
 				found = true
 				break
 			}
 		}
 		if !found {
-			env = append(env, strings.Join([]string{name, value}, "="))
+			*env = append(*env, strings.Join([]string{key, value}, "="))
 		}
 	}
 	return rest, nil
+}
+
+// Parses $ENV_VAR arguments. `env` is a slice of "key=value" strings.
+// Returns an error if it cannot find a matching environment
+// variable.
+func parseEnvArgs(args *[]string, env []string) error {
+	// TODO: actually parse arguments
+	for i, arg := range *args {
+		envArg, found := strings.CutPrefix(arg, "$")
+		if !found {
+			continue
+		}
+
+		found = false
+		for _, envVar := range env {
+			if strings.HasPrefix(envVar, envArg) {
+				(*args)[i] = envVar[len(envArg)+1:]
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("%w: cannot find environment variable %s", os.ErrInvalid, envArg)
+		}
+	}
+
+	return nil
 }
 
 func unpackArray[S ~[]E, E any](s S) []any {

--- a/shell/util.go
+++ b/shell/util.go
@@ -35,7 +35,7 @@ func isWasmFile(name string) bool {
 	return bytes.Equal(magic, WASM_MAGIC)
 }
 
-func parseEnvArgs(args []string, env map[string]string) (rest []string, err error) {
+func parseEnvArgs(args []string, env []string) (rest []string, err error) {
 	for i, arg := range args {
 		name, value, found := strings.Cut(arg, "=")
 		if !found {
@@ -45,7 +45,18 @@ func parseEnvArgs(args []string, env map[string]string) (rest []string, err erro
 		if name == "" {
 			return rest, fmt.Errorf("invalid variable at arg %d", i)
 		}
-		env[name] = value
+
+		found = false
+		for j, entry := range env {
+			if strings.HasPrefix(entry, name) {
+				env[j] = strings.Join([]string{name, value}, "=")
+				found = true
+				break
+			}
+		}
+		if !found {
+			env = append(env, strings.Join([]string{name, value}, "="))
+		}
 	}
 	return rest, nil
 }
@@ -67,7 +78,7 @@ func unpackMap(m map[string]string) map[string]any {
 }
 
 func packEnv(m map[string]string) []string {
-	r := make([]string, len(m))
+	r := make([]string, 0, len(m))
 	for k, v := range m {
 		r = append(r, strings.Join([]string{k, v}, "="))
 	}


### PR DESCRIPTION
Closes #37
Closes #56

This PR implements compiling build tool's `pkg.zip` from source and running it in a shell script. Had to shave a yak or two in the process, but it finally works!

One thing to note: `compile.wasm` and `link.wasm` are compiled from the user's local Go installation. This could cause compatibility issues between users in the future, as their Wanix instances may be compiled with different Go versions, but it's the simplest way to complete this for now.
