### PR TITLE
shell: support script argument expansion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module tractor.dev/wanix
 go 1.21.1
 
 require (
+	github.com/Parzival-3141/go-posix v0.0.0-20240117234226-973522973253
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be
 	github.com/evanw/esbuild v0.19.5
-	github.com/mgood/go-posix v0.0.0-20150821180505-948c005421f5
 	github.com/spf13/afero v1.10.0
 	golang.org/x/term v0.13.0
 	tractor.dev/toolkit-go v0.0.0-20231221004400-0208bc4b870f

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Parzival-3141/go-posix v0.0.0-20240117234226-973522973253 h1:PoAWY9pmlS5qRFr5FME51nyfYnNkoeTH009lvNR2XjA=
+github.com/Parzival-3141/go-posix v0.0.0-20240117234226-973522973253/go.mod h1:Rfx4vn0rqzMiKHC4STvCa2/8iv0r8fvGXjkBxhbvAQU=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -125,8 +127,6 @@ github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/mgood/go-posix v0.0.0-20150821180505-948c005421f5 h1:AutzcJSqc7ROMqcjPKmxwLl//YrzDPb4tLSBlH3Irdc=
-github.com/mgood/go-posix v0.0.0-20150821180505-948c005421f5/go.mod h1:irVTeKOI2GrudEK6/mqR4dDlGH91lCZIZM34YKSKH7M=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/shell/main.go
+++ b/shell/main.go
@@ -143,7 +143,9 @@ __\      /___|  (__)  |_|  |___\   |_(      )_/  /__\  \_
 			m.printErr(fmt.Errorf("exec error: %w", err))
 		}
 
-		fmt.Println()
+		if m.script == nil {
+			fmt.Println()
+		}
 	}
 }
 

--- a/shell/main.go
+++ b/shell/main.go
@@ -132,22 +132,10 @@ __\      /___|  (__)  |_|  |___\   |_(      )_/  /__\  \_
 			continue
 		}
 
-		args, err := preprocess(line)
+		args, err := m.preprocess(line)
 		if err != nil {
 			m.printErr(fmt.Errorf("parsing error: %w", err))
 			continue
-		}
-
-		if err = parseEnvArgs(&args, os.Environ()); err != nil {
-			m.printErr(err)
-			continue
-		}
-
-		if m.script != nil {
-			if err = m.parseScriptArgs(&args); err != nil {
-				m.printErr(err)
-				continue
-			}
 		}
 
 		ctx := cli.ContextWithIO(context.Background(), m.defaultStdin, os.Stdout, os.Stderr)
@@ -277,35 +265,4 @@ func findCommand(name string, args []string) (*exec.Cmd, error) {
 	}
 
 	return nil, fmt.Errorf("unable to find command: %s", name)
-}
-
-// Parses $0-255 arguments, replacing with script input args.
-func (m *Shell) parseScriptArgs(args *[]string) error {
-	// TODO: actually parse arguments
-	// for i, arg := range *args {
-	// numArg, found := strings.CutPrefix(arg, "$")
-	// if !found {
-	// 	continue
-	// }
-
-	// j, err := strconv.ParseUint(numArg, 10, 8)
-	// if err != nil {
-	// 	return err
-	// }
-
-	// if uint(j) >= uint(len(os.Args)) {
-	// 	return fmt.Errorf("%w: positional argument %d >= number of arguments %d", os.ErrInvalid, j, len(os.Args))
-	// }
-
-	// (*args)[i] = os.Args[j]
-	// }
-
-	scriptArgs := os.Args[1:]
-	if len(scriptArgs) > 1 {
-		for i, arg := range *args {
-			(*args)[i] = strings.ReplaceAll(arg, "$1", scriptArgs[1])
-		}
-	}
-
-	return nil
 }


### PR DESCRIPTION
I forked the go-posix library and added the ability to expand numbered variables (e.g. `/$1/bar/$2 -> /foo/bar/baz`). Cleaned unecessary functions as well.