### PR TITLE
saves a red squiggle for vscode workspace settings cuz syscall/js

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing
+
+## Development
+
+### Editors
+
+**VSCODE**
+
+- [Go for Visual Studio (Recommended)](https://marketplace.visualstudio.com/items?itemName=golang.go)
+
+- Workspace Settings:
+
+  - Since we are using `syscall/js`, we need to set the `GOOS` and `GOARCH` environment variables to `js` and `wasm` respectively.
+
+  ```json
+  {
+    "go.toolsEnvVars": {
+      "GOOS": "js",
+      "GOARCH": "wasm"
+    }
+  }
+  ```
+
+---


### PR DESCRIPTION
Tiny start on `CONTRIBUTING.md` - I think it will be particularly useful for developers who want to get started. I found something minor to help out in vscode, I am sure there will be more.