### PR TITLE
Fix `indexedfs` error handling and complete `mv` command

### DIFF
--- a/internal/indexedfs/indexedfs.go
+++ b/internal/indexedfs/indexedfs.go
@@ -18,9 +18,34 @@ import (
 
 var helper js.Value = js.Undefined()
 
-func callHelper(name string, args ...any) js.Value {
-	//jsutil.Log(name, args)
-	return helper.Call(name, args...)
+var ErrReadingBlob = errors.New("ErrReadingBlob")
+
+func callHelperAwait(name string, args ...any) (value js.Value, err error) {
+	// jsutil.Log(name, args)
+
+	value, jsErr := jsutil.AwaitErr(helper.Call(name, args...))
+	if jsErr != nil {
+		goErrorName := jsErr.(js.Error).Get("goErrorName")
+		if goErrorName.Truthy() {
+			var goErr error
+			switch goErrorName.String() {
+			case "ErrNotExist":
+				goErr = fs.ErrNotExist
+			case "ErrExist":
+				goErr = fs.ErrExist
+			case "ErrReadingBlob":
+				goErr = ErrReadingBlob
+			default:
+				panic(fmt.Sprint("unexpected error:", goErrorName.String()))
+			}
+
+			err = errors.Join(goErr, jsErr)
+		} else {
+			err = jsErr
+		}
+	}
+
+	return value, err
 }
 
 type FS struct {
@@ -34,7 +59,7 @@ func New() (*FS, error) {
 		helper = jsutil.Await(js.Global().Call("import", url))
 	}
 
-	db, err := jsutil.AwaitErr(callHelper("initialize"))
+	db, err := callHelperAwait("initialize")
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +79,7 @@ func (ifs *FS) Chmod(name string, mode fs.FileMode) error {
 	})
 	defer updateFunc.Release()
 
-	if _, err := jsutil.AwaitErr(callHelper("updateFile", ifs.db, name, updateFunc)); err != nil {
+	if _, err := callHelperAwait("updateFile", ifs.db, name, updateFunc); err != nil {
 		return &fs.PathError{Op: "chmod", Path: name, Err: err}
 	}
 
@@ -77,7 +102,7 @@ func (ifs *FS) Chtimes(name string, atime time.Time, mtime time.Time) error {
 	})
 	defer updateFunc.Release()
 
-	if _, err := jsutil.AwaitErr(callHelper("updateFile", ifs.db, name, updateFunc)); err != nil {
+	if _, err := callHelperAwait("updateFile", ifs.db, name, updateFunc); err != nil {
 		return &fs.PathError{Op: "chtimes", Path: name, Err: err}
 	}
 
@@ -101,7 +126,7 @@ func (ifs *FS) Mkdir(name string, perm fs.FileMode) error {
 		}
 	}
 
-	_, err := jsutil.AwaitErr(callHelper("addFile", ifs.db, name, uint32(perm), true, time.Now().Unix()))
+	_, err := callHelperAwait("addFile", ifs.db, name, uint32(perm), true, time.Now().Unix())
 	if err != nil {
 		return &fs.PathError{Op: "mkdir", Path: name, Err: err}
 	}
@@ -156,7 +181,7 @@ func (ifs *FS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error
 		err  error = nil
 	)
 
-	key, err = jsutil.AwaitErr(callHelper("getFileKey", ifs.db, name))
+	key, err = callHelperAwait("getFileKey", ifs.db, name)
 	if err == nil {
 		file = &indexedFile{name: name, key: key.Int(), ifs: ifs, flags: flag}
 	}
@@ -166,10 +191,9 @@ func (ifs *FS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error
 	}
 
 	if err != nil {
-		// TODO: figure out a better way of signaling error type from javascript
-		if strings.Contains(err.Error(), "ErrNotExist") {
+		if errors.Is(err, fs.ErrNotExist) {
 			if flag&os.O_CREATE > 0 {
-				key, err = jsutil.AwaitErr(callHelper("addFile", ifs.db, name, uint32(perm), perm.IsDir(), time.Now().Unix()))
+				key, err = callHelperAwait("addFile", ifs.db, name, uint32(perm), perm.IsDir(), time.Now().Unix())
 				if err != nil {
 					return nil, &fs.PathError{Op: "open", Path: name, Err: err}
 				}
@@ -204,7 +228,7 @@ func (ifs *FS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error
 		})
 		defer updateFunc.Release()
 
-		if _, err = jsutil.AwaitErr(callHelper("updateFile", ifs.db, name, updateFunc)); err != nil {
+		if _, err = callHelperAwait("updateFile", ifs.db, name, updateFunc); err != nil {
 			return nil, &fs.PathError{Op: "open", Path: name, Err: err}
 		}
 	}
@@ -216,11 +240,11 @@ func (ifs *FS) Remove(name string) error {
 	if !fs.ValidPath(name) {
 		return &fs.PathError{Op: "remove", Path: name, Err: fs.ErrInvalid}
 	}
-	key, err := jsutil.AwaitErr(callHelper("getFileKey", ifs.db, name))
+	key, err := callHelperAwait("getFileKey", ifs.db, name)
 	if err != nil {
 		return &fs.PathError{Op: "remove", Path: name, Err: err}
 	}
-	if _, err = jsutil.AwaitErr(callHelper("deleteFile", ifs.db, key)); err != nil {
+	if _, err = callHelperAwait("deleteFile", ifs.db, key); err != nil {
 		return &fs.PathError{Op: "remove", Path: name, Err: err}
 	}
 
@@ -231,7 +255,7 @@ func (ifs *FS) RemoveAll(path string) error {
 	if !fs.ValidPath(path) {
 		return &fs.PathError{Op: "removeAll", Path: path, Err: fs.ErrInvalid}
 	}
-	if _, err := jsutil.AwaitErr(callHelper("deleteAll", ifs.db, path)); err != nil {
+	if _, err := callHelperAwait("deleteAll", ifs.db, path); err != nil {
 		return &fs.PathError{Op: "removeAll", Path: path, Err: err}
 	}
 	return nil
@@ -245,9 +269,9 @@ func (ifs *FS) Rename(oldname, newname string) error {
 		return &fs.PathError{Op: "rename", Path: newname, Err: fs.ErrInvalid}
 	}
 
-	key, err := jsutil.AwaitErr(callHelper("getFileKey", ifs.db, oldname))
+	key, err := callHelperAwait("getFileKey", ifs.db, oldname)
 	if err != nil {
-		return &fs.PathError{Op: "rename", Path: newname, Err: err}
+		return &fs.PathError{Op: "rename", Path: oldname, Err: err}
 	}
 
 	updateFunc := js.FuncOf(func(this js.Value, args []js.Value) any {
@@ -258,8 +282,8 @@ func (ifs *FS) Rename(oldname, newname string) error {
 	})
 	defer updateFunc.Release()
 
-	if _, err = jsutil.AwaitErr(callHelper("updateFile", ifs.db, key, updateFunc)); err != nil {
-		return &fs.PathError{Op: "rename", Path: newname, Err: err}
+	if _, err = callHelperAwait("updateFile", ifs.db, key, updateFunc); err != nil {
+		return &fs.PathError{Op: "rename", Path: oldname, Err: err}
 	}
 
 	return nil
@@ -270,7 +294,7 @@ func (ifs *FS) Stat(name string) (fs.FileInfo, error) {
 		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrInvalid}
 	}
 
-	f, err := jsutil.AwaitErr(callHelper("getFileByPath", ifs.db, name))
+	f, err := callHelperAwait("getFileByPath", ifs.db, name)
 	if err != nil {
 		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrNotExist}
 	}
@@ -288,7 +312,7 @@ func (ifs *FS) ReadDir(name string) ([]fs.DirEntry, error) {
 		return nil, &fs.PathError{Op: "readDir", Path: name, Err: fs.ErrInvalid}
 	}
 
-	entries, err := jsutil.AwaitErr(callHelper("getDirEntries", ifs.db, name))
+	entries, err := callHelperAwait("getDirEntries", ifs.db, name)
 	if err != nil {
 		return nil, &fs.PathError{Op: "readdir", Path: name, Err: err}
 	}
@@ -329,7 +353,7 @@ func (f *indexedFile) getData() ([]byte, error) {
 	if f.outdatedRead || f.readCache == nil {
 		// Deliberately not updating atime, as that can get slow fast.
 		// Aiming for posix-like, not compliant.
-		data, err := jsutil.AwaitErr(callHelper("readFile", f.ifs.db, f.key))
+		data, err := callHelperAwait("readFile", f.ifs.db, f.key)
 		if err != nil {
 			return nil, err
 		}
@@ -443,7 +467,7 @@ func (f *indexedFile) Sync() error {
 	})
 	defer updateFunc.Release()
 
-	_, err := jsutil.AwaitErr(callHelper("updateFile", f.ifs.db, f.key, updateFunc))
+	_, err := callHelperAwait("updateFile", f.ifs.db, f.key, updateFunc)
 	if err != nil {
 		return &fs.PathError{Op: "sync", Path: f.name, Err: err}
 	}

--- a/internal/indexedfs/indexedfs.js
+++ b/internal/indexedfs/indexedfs.js
@@ -94,7 +94,10 @@ export function updateFile(db, pathOrKey, updateCallback) {
 
 		const onFailure = (event) => {
 			event.stopPropagation();
-			reject(goError(`Couldn't find file with key ${pathOrKey}: ${event.target.error}`, "ErrNotExist"));
+			reject(goError(
+				`Couldn't find file with key ${pathOrKey}: ${event.target.error}`, 
+				event.target.error.name === "ConstraintError" ? "ErrExist" : "ErrNotExist"
+			));
 		};
 
 		request.onsuccess = (event) => {

--- a/internal/indexedfs/indexedfs.js
+++ b/internal/indexedfs/indexedfs.js
@@ -17,7 +17,7 @@ export function initialize() {
 		const OpenDBRequest = indexedDB.open("indexedFS");
 
 		OpenDBRequest.onerror = (event) => {
-			reject(new Error(`Unable to open IndexedDB: ${event.target.error}`));
+			reject(goError(`Unable to open IndexedDB: ${event.target.error}`), null);
 		};
 		OpenDBRequest.onsuccess = (reqEvent) => {
 			const db = reqEvent.target.result;
@@ -57,29 +57,28 @@ export function initialize() {
 
 export function addFile(db, path, perms, isdir, unixTime) {
 	return new Promise((resolve, reject) => {
-		const transaction = db.transaction("files", "readwrite");
+		const req = 
+			db.transaction("files", "readwrite")
+			.objectStore("files")
+			.add({
+				path: path,
+				perms: perms,
+				size: 0,
+				isdir: isdir,
+				ctime: unixTime,
+				mtime: unixTime,
+				atime: unixTime,
+				blob: new Blob([""], {
+					type: "text/plain"
+				}),
+			});
 
-		transaction.onerror = (event) => {
-			event.stopPropagation();
-			reject(new Error(`addFile transaction failed: ${event.target.error}`));
+		req.onsuccess = (event) => {
+			resolve(event.target.result) // return key
 		};
 
-		const fileStore = transaction.objectStore("files");
-		const addRequest = fileStore.add({
-			path: path,
-			perms: perms,
-			size: 0,
-			isdir: isdir,
-			ctime: unixTime,
-			mtime: unixTime,
-			atime: unixTime,
-			blob: new Blob([""], {
-				type: "text/plain"
-			}),
-		});
-
-		addRequest.onsuccess = (event) => {
-			resolve(event.target.result) // return key
+		req.onerror = (event) => {
+			reject(goError(`Failed to add file at path ${path}: ${event.target.error}`), "ErrExist");
 		};
 	});
 }
@@ -87,29 +86,29 @@ export function addFile(db, path, perms, isdir, unixTime) {
 // updateCallback takes a file object, modifies, and returns it.
 export function updateFile(db, pathOrKey, updateCallback) {
 	return new Promise((resolve, reject) => {
-		const transaction = db.transaction("files", "readwrite");
-
-		// any errors should bubble up to this handler
-		transaction.onerror = (event) => {
-			event.stopPropagation();
-			reject(new Error(`updateFile transaction failed: ${event.target.error}`));
-		};
-
-		const fileStore = transaction.objectStore("files");
-		const cursorRequest =
+		const fileStore = db.transaction("files", "readwrite").objectStore("files");
+		const request =
 			typeof pathOrKey === "string" ?
 			fileStore.index("path").openCursor(pathOrKey) :
 			fileStore.openCursor(pathOrKey);
 
-		cursorRequest.onsuccess = (event) => {
+		const onFailure = (event) => {
+			reject(goError(`Couldn't find file with key ${pathOrKey}: ${event.target.error}`, "ErrNotExist"));
+		};
+
+		request.onsuccess = (event) => {
 			const cursor = event.target.result;
 			if(cursor) {
 				const file = updateCallback(cursor.value);
-				cursor.update(file).onsuccess = () => resolve();
+				const updateReq = cursor.update(file)
+				updateReq.onsuccess = () => resolve();
+				updateReq.onerror = onFailure;
 			} else {
-				reject(new Error(`Couldn't find file with key ${pathOrKey}`));
+				reject(goError(`Couldn't find file with key ${pathOrKey}`, "ErrNotExist"));
 			}
 		};
+
+		request.onerror = onFailure;
 	});
 }
 
@@ -128,12 +127,13 @@ export function getFileKey(db, path) {
 			if(event.target.result) {
 				resolve(req.result);
 			} else {
-				reject(new Error(`ErrNotExist: Failed to find file at path: ${path}`));
+				console.warn("inside getFileKey, no data error")
+				reject(goError(`Failed to find file at path: ${path}`, "ErrNotExist"));
 			}
 		};
 
 		req.onerror = (event) => {
-			reject(new Error(`Failed to find file at path ${path}: ${event.target.error}`));
+			reject(goError(`Failed to find file at path ${path}: ${event.target.error}`, "ErrNotExist"));
 		};
 	});
 }
@@ -172,7 +172,7 @@ export function getDirEntries(db, path) {
 		};
 
 		getRequest.onerror = (event) => {
-			reject(new Error(`Failed to find dir at path ${path}: ${event.target.error}`));
+			reject(goError(`Failed to find dir at path ${path}: ${event.target.error}`, "ErrNotExist"));
 		};
 	});
 }
@@ -189,12 +189,12 @@ export function getFileByPath(db, path) {
 			if(event.target.result) {
 				resolve(getRequest.result);
 			} else {
-				reject(new Error(`ErrNotExist: Failed to find file at path: ${path}`));
+				reject(goError(`Failed to find file at path: ${path}`, "ErrNotExist"));
 			}
 		};
 
 		getRequest.onerror = (event) => {
-			reject(new Error(`Failed to find file at path ${path}: ${event.target.error}`));
+			reject(goError(`Failed to find file at path ${path}: ${event.target.error}`, "ErrNotExist"));
 		};
 	});
 }
@@ -206,16 +206,21 @@ export function readFile(db, key) {
 			.objectStore("files")
 			.get(key);
 
-		getRequest.onsuccess = (event) => {
+		getRequest.onsuccess = async (event) => {
 			if(event.target.result) {
-				resolve(blobToUint8Array(event.target.result.blob));
+				try {
+					const data = await event.target.result.blob.arrayBuffer();
+					resolve(new Uint8Array(data));
+				} catch (rejected) {
+					reject(goError(rejected instanceof Error ? rejected.message : String(rejected), "ErrReadingBlob"));
+				}
 			} else {
-				reject(new Error(`ErrNotExist: Failed to read file with key ${key}`))
+				reject(goError(`Failed to read file with key ${key}`, "ErrNotExist"));
 			}
 		};
 
 		getRequest.onerror = (event) => {
-			reject(new Error(`Failed to read file with key ${key}: ${event.target.error}`))
+			reject(goError(`Failed to read file with key ${key}: ${event.target.error}`, "ErrNotExist"));
 		};
 	})
 }
@@ -229,17 +234,15 @@ export function deleteFile(db, key) {
 
 		req.onsuccess = () => resolve();
 		req.onerror = (event) => {
-			reject(new Error(`Failed to delete file with key ${key}: ${event.target.error}`))
+			reject(goError(`Failed to delete file with key ${key}: ${event.target.error}`, "ErrNotExist"));
 		};
 	})
 }
 
 
 export function deleteAll(db, path) {
-	if (path === "." || path === "") {
-		console.warn("deleteAll invalid path:", path)
-		return; // error? allow it? 
-	}
+	// Assumes path !== "." or ""
+	// This is asserted by the caller.
 
 	let dirpath = path;
 	if (path && path[path.length - 1] !== '/') {
@@ -264,38 +267,15 @@ export function deleteAll(db, path) {
 
 		tx.oncomplete = () => resolve();
 		tx.onerror = (event) => {
-			reject(new Error(`DeleteAll failure: ${path}: ${event.target.errorCode}`));
+			reject(goError(`DeleteAll failure: ${path}: ${event.target.errorCode}`, "ErrNotExist"));
 		};
 	});
 }
 
-export function blobToUint8Array(blob) {
-	return new Promise((resolve, reject) => {
-		const reader = new FileReader();
-
-		reader.onloadend = function() {
-			resolve(new Uint8Array(reader.result));
-		};
-
-		reader.onerror = function() {
-			reject(new Error("Failed to read blob"));
-		};
-
-		reader.readAsArrayBuffer(blob);
-	});
+function goError(message, goErrorName) {
+	let err = new Error(message);
+	if(goErrorName) {
+		err.goErrorName = goErrorName;
+	}
+	return err;
 }
-
-// function writefile(path, content) {
-// 	path = cleanPath(path);
-// 	let node = makeNode(path);
-// 	if (typeof content === "string") {
-// 		content = new Blob([content], {
-// 			type: "text/plain"
-// 		});
-// 	}
-// 	let bs = await createBinaryStreamFromBlob(content, window.wanix.collab.group);
-// 	node.mutate(n => {
-// 		n.set("dataID", bs.id);
-// 		n.set("dataSize", content.size);
-// 	})
-// }

--- a/internal/indexedfs/indexedfs.js
+++ b/internal/indexedfs/indexedfs.js
@@ -93,6 +93,7 @@ export function updateFile(db, pathOrKey, updateCallback) {
 			fileStore.openCursor(pathOrKey);
 
 		const onFailure = (event) => {
+			event.stopPropagation();
 			reject(goError(`Couldn't find file with key ${pathOrKey}: ${event.target.error}`, "ErrNotExist"));
 		};
 
@@ -127,7 +128,6 @@ export function getFileKey(db, path) {
 			if(event.target.result) {
 				resolve(req.result);
 			} else {
-				console.warn("inside getFileKey, no data error")
 				reject(goError(`Failed to find file at path: ${path}`, "ErrNotExist"));
 			}
 		};

--- a/kernel/web/lib/duplex.js
+++ b/kernel/web/lib/duplex.js
@@ -2498,7 +2498,7 @@ var Client = class {
       const resp = new Response(ch, framer);
       resp.error = header.E;
       if (resp.error !== void 0 && resp.error !== null) {
-        throw resp.error;
+        throw new Error(resp.error);
       }
       resp.value = await dec.decode();
       resp.continue = header.C;
@@ -2591,7 +2591,7 @@ var RespondMux = class {
   }
   handle(selector, handler) {
     if (selector === "") {
-      throw "handle: invalid selector";
+      throw new Error("handle: invalid selector");
     }
     let pattern = cleanSelector(selector);
     const matcher = handler;
@@ -2599,10 +2599,10 @@ var RespondMux = class {
       pattern = pattern + "/";
     }
     if (!handler) {
-      throw "handle: invalid handler";
+      throw new Error("handle: invalid handler");
     }
     if (this.match(pattern)) {
-      throw "handle: selector already registered";
+      throw new Error("handle: selector already registered");
     }
     this.handlers[pattern] = handler;
   }
@@ -2823,7 +2823,7 @@ function Marshal(obj) {
     data.setUint32(5, m.additionalBytes);
     return new Uint8Array(data.buffer);
   }
-  throw `marshal of unknown type: ${obj}`;
+  throw new Error(`marshal of unknown type: ${obj}`);
 }
 
 // mux/util.ts
@@ -2844,7 +2844,7 @@ var queue = class {
   }
   push(obj) {
     if (this.closed)
-      throw "closed queue";
+      throw new Error("closed queue");
     if (this.waiters.length > 0) {
       const waiter = this.waiters.shift();
       if (waiter)
@@ -3039,7 +3039,7 @@ function Unmarshal(packet) {
         additionalBytes: data.getUint32(5)
       };
     default:
-      throw `unmarshal of unknown type: ${packet[0]}`;
+      throw new Error(`unmarshal of unknown type: ${packet[0]}`);
   }
 }
 
@@ -3074,7 +3074,7 @@ var Session = class {
     if (await ch.ready.shift()) {
       return ch;
     }
-    throw "failed to open";
+    throw new Error("failed to open");
   }
   accept() {
     return this.incoming.shift();
@@ -3108,7 +3108,7 @@ var Session = class {
           if (this.closed) {
             return;
           }
-          throw `invalid channel (${cmsg.channelID}) on op ${cmsg.ID}`;
+          throw new Error(`invalid channel (${cmsg.channelID}) on op ${cmsg.ID}`);
         }
         await ch.handle(cmsg);
       }
@@ -3299,7 +3299,7 @@ var Channel = class {
   }
   send(msg) {
     if (this.sentClose) {
-      throw "EOF";
+      throw new Error("EOF");
     }
     this.sentClose = msg.ID === CloseID;
     return this.session.enc.encode(msg);
@@ -3323,7 +3323,7 @@ var Channel = class {
     }
     if (msg.ID === OpenConfirmID) {
       if (msg.maxPacketSize < minPacketLength || msg.maxPacketSize > maxPacketLength) {
-        throw "invalid max packet size";
+        throw new Error("invalid max packet size");
       }
       this.remoteId = msg.senderID;
       this.maxRemotePayload = msg.maxPacketSize;
@@ -3337,10 +3337,10 @@ var Channel = class {
   }
   handleData(msg) {
     if (msg.length > this.maxIncomingPayload) {
-      throw "incoming packet exceeds maximum payload size";
+      throw new Error("incoming packet exceeds maximum payload size");
     }
     if (this.myWindow < msg.length) {
-      throw "remote side wrote too much";
+      throw new Error("remote side wrote too much");
     }
     this.myWindow -= msg.length;
     this.readBuf.write(msg.data);

--- a/kernel/web/lib/task.js
+++ b/kernel/web/lib/task.js
@@ -61,7 +61,7 @@ export class Task {
 
   async terminate() {
     if (!this.worker) {
-      throw "no worker";
+      throw new Error("no worker");
     }
 
     await this.pipe.close();
@@ -70,7 +70,7 @@ export class Task {
 
   async wait() {
     if (!this.worker) {
-      throw "no worker";
+      throw new Error("no worker");
     }
 
     const resp = await this.finished;
@@ -79,7 +79,7 @@ export class Task {
 
   async stdout() {
     if (!this.worker) {
-      throw "no worker";
+      throw new Error("no worker");
     }
     const resp = await this.call("stdout");
     return resp.channel;
@@ -87,7 +87,7 @@ export class Task {
 
   async stderr() {
     if (!this.worker) {
-      throw "no worker";
+      throw new Error("no worker");
     }
     const resp = await this.call("stderr");
     return resp.channel;
@@ -95,7 +95,7 @@ export class Task {
 
   async output() {
     if (!this.worker) {
-      throw "no worker";
+      throw new Error("no worker");
     }
     const resp = await this.call("output");
     return resp.channel;
@@ -103,7 +103,7 @@ export class Task {
 
   async stdin() {
     if (!this.worker) {
-      throw "no worker";
+      throw new Error("no worker");
     }
     const resp = await this.call("stdin");
     return resp.channel;

--- a/kernel/web/lib/wasm.js
+++ b/kernel/web/lib/wasm.js
@@ -20,17 +20,16 @@
 	}
 
 	const inflateErr = (err) => {
-		if (!err.includes(";")) {
+		if (!err.message.includes(";")) {
 			return err;
 		}
-		const [msg, params] = err.split(";");
+		const [msg, params] = err.message.split(";");
 		const obj = params.split(",").reduce((obj, pair) => {
 			const [key, value] = pair.split('=');
 			obj[key.trim()] = value.trim();
 			return obj;
 		}, {});
-		const e = new Error(msg);
-		return Object.assign(e, obj);
+		return Object.assign(new Error(msg), obj);
 	}
 
   if (!globalThis.stdin) {


### PR DESCRIPTION
Closes #79 

Turns out one of those pesky `todo`s came back to haunt me, go figure. The panic was due to how we resolve filesystem errors to error codes for syscalls. `indexedfs` helper calls were returning generic `syscall/js.Error` errors which we couldn't properly resolve in `jsutil.go:ToJSError()`, causing a panic in the `os` package which expected to find an error code.

I fixed this by explicitly stating which Go error to return when erroring in the JS helper. I also finished the `mv` command and did some other cleanup.