### PR TITLE
shell: fix glob expansion and `rm` multiple arguments

### DIFF
--- a/kernel/proc/proc.go
+++ b/kernel/proc/proc.go
@@ -174,6 +174,9 @@ func (s *Service) buildCmdSource(path, workingDir string) (wasmPath string, err 
 	}
 
 	if shouldBuild {
+		if path == "sys/cmd/shell" {
+			jsutil.Log("Building Shell...")
+		}
 		p, err := s.Spawn(
 			"/sys/cmd/build.wasm",
 			[]string{"-output", wasmPath, path},

--- a/shell/preprocessor.go
+++ b/shell/preprocessor.go
@@ -1,5 +1,6 @@
 package main
 
+//adasds
 import (
 	"os"
 	"path/filepath"
@@ -34,9 +35,16 @@ func (m *Shell) preprocess(input string) ([]string, error) {
 
 	result := []string{}
 	for _, arg := range args {
+		if strings.ContainsRune(arg, '$') {
+			val, err := posix.Expand(arg, mapping)
+			if err != nil {
+				return result, err
+			}
+			arg = val
+		}
 
 		if strings.ContainsAny(arg, "*?[") {
-			matches, err := filepath.Glob(arg)
+			matches, err := filepath.Glob(absPath(arg))
 			if err != nil {
 				return result, err
 			}
@@ -44,15 +52,6 @@ func (m *Shell) preprocess(input string) ([]string, error) {
 			for _, match := range matches {
 				result = append(result, match)
 			}
-			continue
-		}
-
-		if strings.ContainsRune(arg, '$') {
-			val, err := posix.Expand(arg, mapping)
-			if err != nil {
-				return result, err
-			}
-			result = append(result, val)
 			continue
 		}
 

--- a/shell/smallcmds.go
+++ b/shell/smallcmds.go
@@ -166,25 +166,26 @@ func removeCmd() *cli.Command {
 		Usage: "rm [-r] <path>...",
 		Args:  cli.MinArgs(1),
 		Run: func(ctx *cli.Context, args []string) {
-			// TODO: multiple files
-			if recursive {
-				err := os.RemoveAll(absPath(args[0]))
-				if checkErr(ctx, err) {
-					return
-				}
-			} else {
-				if isdir, err := fs.IsDir(os.DirFS("/"), unixToFsPath(args[0])); isdir {
-					fmt.Fprintf(ctx, "Can't remove file %s: is a directory\n(try using the `-r` flag)\n", absPath(args[0]))
-					return
-				} else if checkErr(ctx, err) {
-					return
-				}
+			for _, arg := range args {
+				if recursive {
+					err := os.RemoveAll(absPath(arg))
+					if checkErr(ctx, err) {
+						return
+					}
+				} else {
+					isdir, err := fs.IsDir(os.DirFS("/"), unixToFsPath(arg))
+					if checkErr(ctx, err) {
+						return
+					}
+					if isdir {
+						fmt.Fprintf(ctx, "Can't remove file %s: is a directory\n(try using the `-r` flag)\n", absPath(arg))
+						continue
+					}
 
-				// TODO: fs.Remove gives the wrong error if trying to delete a readonly file,
-				// (should be Operation not permitted)
-				err := os.Remove(absPath(args[0]))
-				if checkErr(ctx, err) {
-					return
+					err = os.Remove(absPath(arg))
+					if checkErr(ctx, err) {
+						return
+					}
 				}
 			}
 		},


### PR DESCRIPTION
Closes #94

I reordered the preprocessor so variable expansion happens first, which allows you to things like `echo $MICRO_CONFIG_HOME/*`. The example in the issue uses `rm` which had an outstanding TODO so I completed that as well.

Added a log when building the shell at startup too.