### PR TITLE
Procfs and Kernel refactor

### DIFF
--- a/internal/procfs/procfs.go
+++ b/internal/procfs/procfs.go
@@ -1,0 +1,218 @@
+package procfs
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"tractor.dev/toolkit-go/engine/fs"
+	"tractor.dev/wanix/kernel/proc"
+)
+
+// TODO: Support searching by PID or exe name.
+// E.g. `/proc/PID/$id` and `/proc/EXE/$name`, where the EXE path returns PIDs
+// only for the given exe (essentially filtering PIDs by EXE name).
+
+type FS struct {
+	ps *proc.Service
+}
+
+func New(p *proc.Service) *FS {
+	return &FS{ps: p}
+}
+
+func (f *FS) Create(name string) (fs.File, error) {
+	return nil, &fs.PathError{Op: "create", Path: name, Err: ErrUnimplemented}
+}
+
+func (f *FS) Open(name string) (fs.File, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
+	}
+
+	if name == "." {
+		return &file{fs: f, isRoot: true}, nil
+	}
+
+	// TODO: hierarchical data?
+	pidStr, _, hasSubpath := strings.Cut(name, "/")
+	if hasSubpath {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
+	}
+
+	pid, err := strconv.ParseInt(pidStr, 0, 0)
+	if err != nil {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: err}
+	}
+
+	p, err := f.ps.Get(int(pid))
+	if err != nil {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: err}
+	}
+
+	return &file{fs: f, proc: *p}, nil
+}
+
+func (f *FS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error) {
+	return f.Open(name)
+}
+
+func (f *FS) Remove(name string) error {
+	return &fs.PathError{Op: "remove", Path: name, Err: ErrUnimplemented}
+}
+func (f *FS) RemoveAll(path string) error {
+	return &fs.PathError{Op: "removeall", Path: path, Err: ErrUnimplemented}
+}
+
+func (f *FS) Stat(name string) (fs.FileInfo, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrInvalid}
+	}
+
+	if name == "." {
+		return &fileInfo{name: name, isDir: true}, nil
+	}
+
+	// TODO: hierarchical data?
+	pidStr, _, hasSubpath := strings.Cut(name, "/")
+	if hasSubpath {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrInvalid}
+	}
+
+	pid, err := strconv.ParseInt(pidStr, 0, 0)
+	if err != nil {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: err}
+	}
+
+	p, err := f.ps.Get(int(pid))
+	if err != nil {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: err}
+	}
+
+	return &fileInfo{name: filepath.Base(p.Path), isDir: false}, nil
+}
+
+type file struct {
+	fs     *FS
+	proc   proc.Process
+	isRoot bool
+
+	buffer []byte
+	offset int64
+}
+
+func (f *file) Close() error {
+	clear(f.buffer)
+	f.offset = 0
+	return nil
+}
+
+func (f *file) Read(b []byte) (int, error) {
+	if f.isRoot {
+		return 0, nil
+	}
+
+	if f.buffer == nil {
+		var err error
+		f.buffer, err = json.MarshalIndent(f.proc, "", "    ")
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	if f.offset >= int64(len(f.buffer)) {
+		return 0, io.EOF
+	}
+
+	var n int
+	rest := f.buffer[f.offset:]
+	if len(rest) < len(b) {
+		n = len(rest)
+	} else {
+		n = len(b)
+	}
+
+	copy(b, rest[:n])
+	f.offset += int64(n)
+	return n, nil
+}
+
+func (f *file) ReadDir(n int) ([]fs.DirEntry, error) {
+	// TODO: hierarchical data?
+	if !f.isRoot {
+		return nil, errors.ErrUnsupported
+	}
+	running := f.fs.ps.GetAll()
+
+	var res []fs.DirEntry
+	for pid := range running {
+		res = append(res, &fileInfo{name: strconv.FormatInt(int64(pid), 10), isDir: false})
+	}
+	return res, nil
+}
+
+func (f *file) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekStart:
+		f.offset = offset
+	case io.SeekCurrent:
+		f.offset += offset
+	case io.SeekEnd:
+		f.offset = int64(len(f.buffer)) + offset
+	}
+	if f.offset < 0 {
+		f.offset = 0
+		return 0, fmt.Errorf("%w: resultant offset cannot be negative", fs.ErrInvalid)
+	}
+	return f.offset, nil
+}
+
+func (f *file) Stat() (fs.FileInfo, error) {
+	return nil, ErrUnimplemented
+}
+
+type fileInfo struct {
+	// base name
+	name  string
+	isDir bool
+}
+
+func (i *fileInfo) Name() string       { return i.name }
+func (i *fileInfo) Size() int64        { return 0 }
+func (i *fileInfo) Mode() fs.FileMode  { return 0444 }
+func (i *fileInfo) ModTime() time.Time { return time.Unix(0, 0) }
+func (i *fileInfo) IsDir() bool        { return i.isDir }
+func (i *fileInfo) Sys() any           { return nil }
+
+// These allow it to act as DirEntry as well
+
+func (i *fileInfo) Info() (fs.FileInfo, error) { return i, nil }
+func (i *fileInfo) Type() fs.FileMode          { return i.Mode() }
+
+// These functions won't be supported
+
+func (f *FS) Chmod(name string, mode fs.FileMode) error {
+	return &fs.PathError{Op: "chmod", Path: name, Err: errors.ErrUnsupported}
+}
+func (f *FS) Chown(name string, uid, gid int) error {
+	return &fs.PathError{Op: "chown", Path: name, Err: errors.ErrUnsupported}
+}
+func (f *FS) Chtimes(name string, atime time.Time, mtime time.Time) error {
+	return &fs.PathError{Op: "chtimes", Path: name, Err: errors.ErrUnsupported}
+}
+func (f *FS) Mkdir(name string, perm fs.FileMode) error {
+	return &fs.PathError{Op: "mkdir", Path: name, Err: errors.ErrUnsupported}
+}
+func (f *FS) MkdirAll(path string, perm fs.FileMode) error {
+	return &fs.PathError{Op: "mkdirall", Path: path, Err: errors.ErrUnsupported}
+}
+func (f *FS) Rename(oldname, newname string) error {
+	return &fs.PathError{Op: "rename", Path: oldname, Err: errors.ErrUnsupported}
+}
+
+var ErrUnimplemented = errors.New("Unimplemented")

--- a/kernel/fs/fs.go
+++ b/kernel/fs/fs.go
@@ -39,10 +39,6 @@ func must(err error) {
 }
 
 type Service struct {
-	// don't love passing this here but kernel
-	// package is a main package so cant reference it
-	KernelSource embed.FS
-
 	fsys fs.MutableFS
 	// Wraps fsys, so it's actually the same filesystem.
 	watcher *watchfs.FS
@@ -62,7 +58,7 @@ func (s *Service) FS() fs.FS {
 	return s.fsys
 }
 
-func (s *Service) Initialize() {
+func (s *Service) Initialize(kernelSource embed.FS) {
 	s.fds = make(map[int]*fd)
 	s.nextFd = 1000
 
@@ -96,7 +92,7 @@ func (s *Service) Initialize() {
 	}
 
 	// copy of kernel source into filesystem.
-	must(s.copyAllFS(s.fsys, "sys/cmd/kernel", s.KernelSource, "."))
+	must(s.copyAllFS(s.fsys, "sys/cmd/kernel", kernelSource, "."))
 
 	// move builtin kernel exe's into filesystem
 	must(s.fsys.Rename("sys/cmd/kernel/bin/build", "sys/cmd/build.wasm"))
@@ -133,7 +129,6 @@ func (s *Service) Initialize() {
 		),
 		"/repo",
 	))
-
 }
 
 func getPrefixedInitFiles(prefix string) []string {

--- a/kernel/main.go
+++ b/kernel/main.go
@@ -1,11 +1,9 @@
 package main
 
 import (
-	"context"
 	"embed"
 	"syscall/js"
 
-	"tractor.dev/toolkit-go/engine"
 	"tractor.dev/wanix/internal/jsutil"
 	"tractor.dev/wanix/kernel/fs"
 	"tractor.dev/wanix/kernel/proc"
@@ -18,25 +16,17 @@ var Source embed.FS
 
 var Version string
 
-func main() {
-	engine.Run(Kernel{},
-		proc.Service{},
-		tty.Service{},
-		web.Gateway{},
-		fs.Service{KernelSource: Source},
-		web.UI{},
-	)
-}
-
-type Component interface {
-	InitializeJS()
-}
-
 type Kernel struct {
-	Components []Component
+	proc    proc.Service
+	tty     tty.Service
+	fs      fs.Service
+	gateway web.Gateway
+	ui      web.UI
 }
 
-func (k *Kernel) Run(ctx context.Context) error {
+func main() {
+	kernel := Kernel{}
+
 	// import syscall.js
 	blob := js.Global().Get("initfs").Get("syscall.js").Get("blob")
 	url := js.Global().Get("URL").Call("createObjectURL", blob)
@@ -44,17 +34,23 @@ func (k *Kernel) Run(ctx context.Context) error {
 
 	// expose syscalls
 	js.Global().Get("api").Set("kernel", map[string]any{
-		"version": js.FuncOf(k.version),
+		"version": js.FuncOf(version),
 	})
 
-	// initialize components
-	for _, c := range k.Components {
-		c.InitializeJS()
-	}
+	// Initialize Go subsystems first, then their JS components
+	kernel.proc.Initialize()
+	kernel.tty.Initialize(&kernel.proc)
+	kernel.fs.Initialize(Source)
+
+	kernel.proc.InitializeJS()
+	kernel.tty.InitializeJS()
+	kernel.fs.InitializeJS()
+	kernel.gateway.InitializeJS()
+	kernel.ui.InitializeJS()
 
 	select {}
 }
 
-func (k *Kernel) version(this js.Value, args []js.Value) any {
+func version(this js.Value, args []js.Value) any {
 	return Version
 }

--- a/kernel/main.go
+++ b/kernel/main.go
@@ -40,7 +40,7 @@ func main() {
 	// Initialize Go subsystems first, then their JS components
 	kernel.proc.Initialize()
 	kernel.tty.Initialize(&kernel.proc)
-	kernel.fs.Initialize(Source)
+	kernel.fs.Initialize(Source, &kernel.proc)
 
 	kernel.proc.InitializeJS()
 	kernel.tty.InitializeJS()

--- a/kernel/proc/proc.go
+++ b/kernel/proc/proc.go
@@ -23,12 +23,20 @@ func (s *Service) Initialize() {
 	s.running = make(map[int]*Process)
 }
 
+type ErrBadPID struct {
+	PID int
+}
+
+func (e *ErrBadPID) Error() string {
+	return fmt.Sprint("no running process with PID ", e.PID)
+}
+
 func (s *Service) Get(pid int) (*Process, error) {
 	s.mu.Lock()
 	p, ok := s.running[pid]
 	s.mu.Unlock()
 	if !ok {
-		return nil, fmt.Errorf("no running process with PID %d", pid)
+		return nil, &ErrBadPID{PID: pid}
 	}
 	return p, nil
 }

--- a/kernel/proc/proc.go
+++ b/kernel/proc/proc.go
@@ -33,6 +33,17 @@ func (s *Service) Get(pid int) (*Process, error) {
 	return p, nil
 }
 
+// Returns a copy of all running processes at the time of invocation.
+func (s *Service) GetAll() map[int]*Process {
+	s.mu.Lock()
+	res := make(map[int]*Process, len(s.running))
+	for k, v := range s.running {
+		res[k] = v
+	}
+	s.mu.Unlock()
+	return res
+}
+
 func (s *Service) Spawn(path string, args []string, env map[string]string, dir string) (*Process, error) {
 	// TODO: check path exists, execute bit
 

--- a/kernel/proc/proc.go
+++ b/kernel/proc/proc.go
@@ -11,11 +11,9 @@ import (
 
 	"tractor.dev/toolkit-go/engine/fs"
 	"tractor.dev/wanix/internal/jsutil"
-	kfs "tractor.dev/wanix/kernel/fs"
 )
 
 type Service struct {
-	FS      *kfs.Service
 	nextPID int
 	running map[int]*Process
 	mu      sync.Mutex

--- a/kernel/tty/tty.go
+++ b/kernel/tty/tty.go
@@ -15,7 +15,8 @@ type Service struct {
 	defaultRows int
 }
 
-func (s *Service) Initialize() {
+func (s *Service) Initialize(p *proc.Service) {
+	s.Proc = p
 	s.defaultCols = 80
 	s.defaultRows = 24
 }


### PR DESCRIPTION
Closes #70 

Basic implementation of `procfs`. Lists running processes under `/sys/proc` indexed by PID. Reading a PID file returns the `proc.Process` serialized to JSON. The format can be changed if required. In the future I'd like to add more structured data and queries using the filesystem.

This PR also reorganizes the kernel, removing the `engine` package. I found it confusing initially, and more of a hinderance than a benefit. I needed more flexibility and control. Rewriting the startup code by hand was simple; now the code is explicit and much easier to follow. I'm not sure what problem `engine` was trying to solve. That being said, the commit can easily be reverted and procfs updated with minor changes if need be.