### PR TITLE
use a different default port ...

### DIFF
--- a/cmd/wanix/serve.go
+++ b/cmd/wanix/serve.go
@@ -41,6 +41,6 @@ func serveCmd() *cli.Command {
 			http.ListenAndServe(":"+port, nil)
 		},
 	}
-	cmd.Flags().StringVar(&port, "port", "8080", "port to serve on")
+	cmd.Flags().StringVar(&port, "port", "7654", "port to serve on")
 	return cmd
 }


### PR DESCRIPTION
... since our service worker takes over the hostname until cleared in browser