### PR TITLE
github: workflow for github actions ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,92 @@
+name: Build
+on: [push]
+
+jobs:
+  build:
+    concurrency: ci-${{ github.ref }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      # Build v86
+      - name: Build v86
+        uses: docker/build-push-action@v5
+        with:
+          context: external/v86
+          push: false
+          load: true
+          tags: wanix-v86-build:latest
+          cache-from: type=local,src=/tmp/.buildx-cache/v86
+          cache-to: type=local,dest=/tmp/.buildx-cache/v86-new,mode=max
+          no-cache: ${{ hashFiles('external/v86/**') != hashFiles('external/v86/**', '.git/refs/remotes/origin/main') }}
+
+      # Build Linux kernel
+      - name: Build Linux
+        uses: docker/build-push-action@v5
+        with:
+          context: external/linux
+          push: false
+          load: true
+          tags: wanix-linux-builder:latest
+          cache-from: type=local,src=/tmp/.buildx-cache/linux
+          cache-to: type=local,dest=/tmp/.buildx-cache/linux-new,mode=max
+          no-cache: ${{ hashFiles('external/linux/**') != hashFiles('external/linux/**', '.git/refs/remotes/origin/main') }}
+
+      # Build WASI
+      - name: Build WASI
+        uses: docker/build-push-action@v5
+        with:
+          context: external/wasi
+          push: false
+          load: true
+          tags: wanix-wasi-builder:latest
+          cache-from: type=local,src=/tmp/.buildx-cache/wasi
+          cache-to: type=local,dest=/tmp/.buildx-cache/wasi-new,mode=max
+          no-cache: ${{ hashFiles('external/wasi/**') != hashFiles('external/wasi/**', '.git/refs/remotes/origin/main') }}
+
+      # Build Shell
+      - name: Build Shell
+        uses: docker/build-push-action@v5
+        with:
+          context: shell
+          push: false
+          load: true
+          tags: wanix-shell-builder:latest
+          cache-from: type=local,src=/tmp/.buildx-cache/shell
+          cache-to: type=local,dest=/tmp/.buildx-cache/shell-new,mode=max
+          no-cache: ${{ hashFiles('shell/**') != hashFiles('shell/**', '.git/refs/remotes/origin/main') }}
+
+      # Move cache
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
+          check-latest: true
+
+      - name: Set up TinyGo
+        run: |
+          wget https://github.com/tinygo-org/tinygo/releases/download/v0.36.0/tinygo_0.36.0_amd64.deb
+          sudo dpkg -i tinygo_0.36.0_amd64.deb
+
+      - name: Build dependencies
+        run: make deps
+
+      - name: Build project
+        run: make build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,9 @@ jobs:
           push: false
           load: true
           tags: wanix-v86-build:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-          no-cache: ${{ hashFiles('external/v86/**') != hashFiles('external/v86/**', '.git/refs/remotes/origin/main') }}
+          cache-from: type=local,src=/tmp/.buildx-cache/v86
+          cache-to: type=local,dest=/tmp/.buildx-cache-new/v86,mode=max
+          no-cache: ${{ github.event_name == 'push' && hashFiles('external/v86/**') != hashFiles('external/v86/**', 'HEAD^') }}
       - run: cd external/v86 && docker run --rm -v "$(pwd):/dst" wanix-v86-build
 
       # Build Linux kernel
@@ -41,9 +41,9 @@ jobs:
           push: false
           load: true
           tags: wanix-linux-builder:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-          no-cache: ${{ hashFiles('external/linux/**') != hashFiles('external/linux/**', '.git/refs/remotes/origin/main') }}
+          cache-from: type=local,src=/tmp/.buildx-cache/linux
+          cache-to: type=local,dest=/tmp/.buildx-cache-new/linux,mode=max
+          no-cache: ${{ github.event_name == 'push' && hashFiles('external/linux/**') != hashFiles('external/linux/**', 'HEAD^') }}
       - run: cd external/linux && docker run --rm -v "$(pwd):/output" wanix-linux-builder
 
       # Build WASI
@@ -54,9 +54,9 @@ jobs:
           push: false
           load: true
           tags: wanix-wasi-builder:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-          no-cache: ${{ hashFiles('external/wasi/**') != hashFiles('external/wasi/**', '.git/refs/remotes/origin/main') }}
+          cache-from: type=local,src=/tmp/.buildx-cache/wasi
+          cache-to: type=local,dest=/tmp/.buildx-cache-new/wasi,mode=max
+          no-cache: ${{ github.event_name == 'push' && hashFiles('external/wasi/**') != hashFiles('external/wasi/**', 'HEAD^') }}
       - run: cd external/wasi && docker run --rm -v "$(pwd):/output" wanix-wasi-builder
 
       # Build Shell
@@ -67,16 +67,18 @@ jobs:
           push: false
           load: true
           tags: wanix-shell-builder:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-          no-cache: ${{ hashFiles('shell/**') != hashFiles('shell/**', '.git/refs/remotes/origin/main') }}
+          cache-from: type=local,src=/tmp/.buildx-cache/shell
+          cache-to: type=local,dest=/tmp/.buildx-cache-new/shell,mode=max
+          no-cache: ${{ github.event_name == 'push' && hashFiles('shell/**') != hashFiles('shell/**', 'HEAD^') }}
       - run: cd shell && docker run --rm -v "$(pwd):/output" wanix-shell-builder
 
       # Move cache
       - name: Move cache
         run: |
           rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          mkdir -p /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new/* /tmp/.buildx-cache/
+          rm -rf /tmp/.buildx-cache-new
 
       - name: Set up Go
         uses: actions/setup-go@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           no-cache: ${{ hashFiles('external/v86/**') != hashFiles('external/v86/**', '.git/refs/remotes/origin/main') }}
+      - run: cd external/v86 && docker run --rm -v "$(pwd):/dst" wanix-v86-build
 
       # Build Linux kernel
       - name: Build Linux
@@ -43,6 +44,7 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           no-cache: ${{ hashFiles('external/linux/**') != hashFiles('external/linux/**', '.git/refs/remotes/origin/main') }}
+      - run: cd external/linux && docker run --rm -v "$(pwd):/output" wanix-linux-builder
 
       # Build WASI
       - name: Build WASI
@@ -55,6 +57,7 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           no-cache: ${{ hashFiles('external/wasi/**') != hashFiles('external/wasi/**', '.git/refs/remotes/origin/main') }}
+      - run: cd external/wasi && docker run --rm -v "$(pwd):/output" wanix-wasi-builder
 
       # Build Shell
       - name: Build Shell
@@ -67,6 +70,7 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           no-cache: ${{ hashFiles('shell/**') != hashFiles('shell/**', '.git/refs/remotes/origin/main') }}
+      - run: cd shell && docker run --rm -v "$(pwd):/output" wanix-shell-builder
 
       # Move cache
       - name: Move cache
@@ -84,9 +88,6 @@ jobs:
         run: |
           wget https://github.com/tinygo-org/tinygo/releases/download/v0.36.0/tinygo_0.36.0_amd64.deb
           sudo dpkg -i tinygo_0.36.0_amd64.deb
-
-      - name: Build dependencies
-        run: make deps
 
       - name: Build project
         run: make build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ jobs:
           push: false
           load: true
           tags: wanix-v86-build:latest
-          cache-from: type=local,src=/tmp/.buildx-cache/v86
-          cache-to: type=local,dest=/tmp/.buildx-cache/v86-new,mode=max
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           no-cache: ${{ hashFiles('external/v86/**') != hashFiles('external/v86/**', '.git/refs/remotes/origin/main') }}
 
       # Build Linux kernel
@@ -40,8 +40,8 @@ jobs:
           push: false
           load: true
           tags: wanix-linux-builder:latest
-          cache-from: type=local,src=/tmp/.buildx-cache/linux
-          cache-to: type=local,dest=/tmp/.buildx-cache/linux-new,mode=max
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           no-cache: ${{ hashFiles('external/linux/**') != hashFiles('external/linux/**', '.git/refs/remotes/origin/main') }}
 
       # Build WASI
@@ -52,8 +52,8 @@ jobs:
           push: false
           load: true
           tags: wanix-wasi-builder:latest
-          cache-from: type=local,src=/tmp/.buildx-cache/wasi
-          cache-to: type=local,dest=/tmp/.buildx-cache/wasi-new,mode=max
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           no-cache: ${{ hashFiles('external/wasi/**') != hashFiles('external/wasi/**', '.git/refs/remotes/origin/main') }}
 
       # Build Shell
@@ -64,8 +64,8 @@ jobs:
           push: false
           load: true
           tags: wanix-shell-builder:latest
-          cache-from: type=local,src=/tmp/.buildx-cache/shell
-          cache-to: type=local,dest=/tmp/.buildx-cache/shell-new,mode=max
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           no-cache: ${{ hashFiles('shell/**') != hashFiles('shell/**', '.git/refs/remotes/origin/main') }}
 
       # Move cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
+      - name: Initialize cache directories
+        run: |
+          mkdir -p /tmp/.buildx-cache/v86
+          mkdir -p /tmp/.buildx-cache/linux
+          mkdir -p /tmp/.buildx-cache/wasi
+          mkdir -p /tmp/.buildx-cache/shell
+          mkdir -p /tmp/.buildx-cache-new/v86
+          mkdir -p /tmp/.buildx-cache-new/linux
+          mkdir -p /tmp/.buildx-cache-new/wasi
+          mkdir -p /tmp/.buildx-cache-new/shell
+
       # Build v86
       - name: Build v86
         uses: docker/build-push-action@v5


### PR DESCRIPTION
This is a first pass at a build workflow for GitHub Actions. It doesn't produce artifacts, but it successfully builds everything. From scratch it takes about 10-12 minutes, and then with dependency Docker builds cached it takes about 5 minutes. Probably half that time is just setting up and tearing down cache. Not ideal, but good enough.

Closes #160 