### PR TITLE
explore/alpine

### DIFF
--- a/cmd/wanix/serve.go
+++ b/cmd/wanix/serve.go
@@ -20,6 +20,7 @@ import (
 	"tractor.dev/wanix/external/linux"
 	v86 "tractor.dev/wanix/external/v86"
 	"tractor.dev/wanix/fs/fskit"
+	"tractor.dev/wanix/hack/alpine"
 	"tractor.dev/wanix/shell"
 	"tractor.dev/wanix/wasm/assets"
 )
@@ -41,9 +42,10 @@ func serveCmd() *cli.Command {
 			fmt.Printf("serving on http://%s:%s ...\n", h, p)
 
 			fsys := fskit.UnionFS{assets.Dir, fskit.MapFS{
-				"v86":   v86.Dir,
-				"linux": linux.Dir,
-				"shell": shell.Dir,
+				"v86":    v86.Dir,
+				"linux":  linux.Dir,
+				"shell":  shell.Dir,
+				"alpine": alpine.Dir,
 			}}
 
 			go serveNetwork()

--- a/hack/alpine/.gitignore
+++ b/hack/alpine/.gitignore
@@ -1,0 +1,2 @@
+alpine.tgz
+i386

--- a/hack/alpine/Makefile
+++ b/hack/alpine/Makefile
@@ -1,0 +1,8 @@
+
+alpine.tgz:
+	go run ./hubpull/main.go i386/alpine latest 386
+	go run ./fixlinks/main.go -input i386/alpine-latest-386/69aa61ccf55e5bf8e7a069b89e8afb42b4f3443b3785868795af8046d810d608.tar.gz -output alpine.tar
+	rm -rf i386
+	tar -rf alpine.tar bin/
+	gzip -c alpine.tar > alpine.tgz
+	rm alpine.tar

--- a/hack/alpine/README.md
+++ b/hack/alpine/README.md
@@ -1,0 +1,56 @@
+# alpine exploration
+
+The `explore/alpine` branch is actively exploring:
+
+- [x] process to get docker hub images for wanix vms
+- [x] working alpine virtual environment
+- [x] networking/internet access from virtual environment
+- [ ] working apk to install packages
+- [ ] benchmark go compiler performance in alpine
+
+## hubpull
+
+There is a proof of concept utility (`hack/alpine/hubpull`) that pulls Docker
+images from Docker Hub directly without Docker. Eventually this could become a
+Wanix capability that creates a mount based on the layers. For now we just use
+it to fetch the `i386/alpine:latest` single layer image.
+
+## alpine
+
+```sh
+make -C hack/alpine
+```
+
+This uses `hubpull` and `fixlinks` (changes absolute symlinks to relative) and
+adds the scripts in `hack/alpine/bin` to produce `hack/alpine/alpine.tgz`. 
+This is embedded and served at `/alpine/alpine.tgz`. 
+
+After the Wanix shell is loaded, in DevTools console you can run `bootAlpine()`.
+This creates another VM using the `alpine.tgz` and a new terminal over the 
+existing one (whole new xterm covering viewport).
+
+This will boot with the custom init script, setting up eth0 and DHCP using the
+virtual network stack that runs with `wanix serve`. It takes a moment longer 
+than the normal shell. If it doesn't, run with `bootAlpine(true)` to see 
+kernel output.
+
+## apk
+
+Currently, running `apk update` fails due to a failed rename operation, which
+should also show up in the DevTools console. 
+
+From the debug error in the console, it seems the filesystem is not resolving
+to one that supports rename. It should resolve to the `#alpine` memfs that's
+mounted at `web/vm/2/fsys`, but doesn't seem to. 
+
+Goal is to update and then install a package.
+
+## go compiler
+
+Any package will prove apk working, but in this exploration I want to install
+the Go toolchain to see how it performs. While we can compile Go to WASI and 
+run it as a wasi task, it performs very poorly. Much worse than the non-WASI
+build we used in 0.2. Perhaps due to the SharedArrayBuffer hack needed for WASI.
+
+While that's a separate issue, I'm hoping an emulated x86 compiler will be fast
+enough for now.

--- a/hack/alpine/bin/init
+++ b/hack/alpine/bin/init
@@ -1,0 +1,28 @@
+#!/bin/busybox sh
+
+# install busybox symlinks
+/bin/busybox --install -s /bin
+
+# fix any broken symlinks.
+# this shouldn't be necessary, but some symlinks
+# end up pointing to nothing. perhaps related to issue #175
+for link in $(/bin/busybox find /bin -maxdepth 1 -type l); do
+  /bin/busybox rm "$link"
+  /bin/busybox ln -s "/bin/busybox" "$link"
+done
+
+# another needed broken symlink not in bin
+rm /usr/lib/libz.so.1
+ln -s /usr/lib/libz.so.1.3.1 /usr/lib/libz.so.1
+
+# configure networking
+echo "nameserver 8.8.8.8" > /etc/resolv.conf
+ifconfig eth0 up
+udhcpc -i eth0 -s /bin/post-dhcp
+
+# configure apk
+echo 'http://dl-cdn.alpinelinux.org/alpine/v3.21/main' > /etc/apk/repositories
+echo 'http://dl-cdn.alpinelinux.org/alpine/v3.21/community' >> /etc/apk/repositories
+
+# start shell
+setsid /bin/busybox sh -c "exec /bin/busybox sh </dev/ttyS0 >/dev/ttyS0 2>&1"

--- a/hack/alpine/bin/post-dhcp
+++ b/hack/alpine/bin/post-dhcp
@@ -1,0 +1,10 @@
+#!/bin/sh
+case "$1" in
+  bound|renew)
+    # Configure interface with IP from DHCP
+    ifconfig $interface $ip netmask $subnet
+
+    # Set up routing
+    route add default gw $router
+    ;;
+esac

--- a/hack/alpine/embed.go
+++ b/hack/alpine/embed.go
@@ -1,0 +1,8 @@
+package alpine
+
+import (
+	"embed"
+)
+
+//go:embed alpine.tgz
+var Dir embed.FS

--- a/hack/alpine/fixlinks/main.go
+++ b/hack/alpine/fixlinks/main.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	// Parse command line flags
+	inputFile := flag.String("input", "", "Input gzipped tar file")
+	outputFile := flag.String("output", "", "Output tar file")
+	flag.Parse()
+
+	if *inputFile == "" || *outputFile == "" {
+		fmt.Println("Usage: program -input input.tar.gz -output output.tar")
+		os.Exit(1)
+	}
+
+	// Open the input file
+	in, err := os.Open(*inputFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error opening input file: %v\n", err)
+		os.Exit(1)
+	}
+	defer in.Close()
+
+	// Create a gzip reader
+	gzReader, err := gzip.NewReader(in)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating gzip reader: %v\n", err)
+		os.Exit(1)
+	}
+	defer gzReader.Close()
+
+	// Create a tar reader
+	tarReader := tar.NewReader(gzReader)
+
+	// Create the output file
+	out, err := os.Create(*outputFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating output file: %v\n", err)
+		os.Exit(1)
+	}
+	defer out.Close()
+
+	// Create a tar writer directly on the output file (removed gzip writer)
+	tarWriter := tar.NewWriter(out)
+	defer tarWriter.Close()
+
+	// Process each file in the tar
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break // End of archive
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading tar: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Check if it's a symlink with an absolute path
+		if header.Typeflag == tar.TypeSymlink && strings.HasPrefix(header.Linkname, "/") {
+			// Get the directory of the symlink
+			symlinkDir := filepath.Dir(header.Name)
+
+			// Convert absolute linkname to relative
+			relLinkname, err := makeRelative(header.Linkname, symlinkDir)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error converting symlink %s -> %s: %v\n",
+					header.Name, header.Linkname, err)
+				continue
+			}
+
+			fmt.Printf("Converting symlink %s: %s -> %s\n", header.Name, header.Linkname, relLinkname)
+			header.Linkname = relLinkname
+		}
+
+		// Write the header
+		if err := tarWriter.WriteHeader(header); err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing header: %v\n", err)
+			os.Exit(1)
+		}
+
+		// If it's a regular file, copy the contents
+		if header.Typeflag == tar.TypeReg {
+			if _, err := io.Copy(tarWriter, tarReader); err != nil {
+				fmt.Fprintf(os.Stderr, "Error copying file contents: %v\n", err)
+				os.Exit(1)
+			}
+		}
+	}
+
+	fmt.Println("Processing complete")
+}
+
+// makeRelative converts an absolute path to a relative path
+// from the perspective of the source directory
+func makeRelative(target, sourceDir string) (string, error) {
+	if !strings.HasPrefix(target, "/") {
+		return target, nil // Already relative
+	}
+
+	// Normalize paths
+	targetPath := filepath.Clean(target)
+	sourcePath := filepath.Clean("/" + sourceDir)
+
+	// Split paths into components
+	targetComponents := strings.Split(targetPath, string(filepath.Separator))
+	sourceComponents := strings.Split(sourcePath, string(filepath.Separator))
+
+	// Remove empty components
+	targetComponents = removeEmpty(targetComponents)
+	sourceComponents = removeEmpty(sourceComponents)
+
+	// Find common prefix
+	commonLen := 0
+	minLen := min(len(targetComponents), len(sourceComponents))
+	for i := 0; i < minLen; i++ {
+		if targetComponents[i] != sourceComponents[i] {
+			break
+		}
+		commonLen++
+	}
+
+	// Build relative path
+	var relPath []string
+
+	// Add "../" for each level we need to go up
+	for i := 0; i < len(sourceComponents)-commonLen; i++ {
+		relPath = append(relPath, "..")
+	}
+
+	// Add the remaining target path components
+	relPath = append(relPath, targetComponents[commonLen:]...)
+
+	return strings.Join(relPath, "/"), nil
+}
+
+func removeEmpty(s []string) []string {
+	var result []string
+	for _, str := range s {
+		if str != "" {
+			result = append(result, str)
+		}
+	}
+	return result
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/hack/alpine/hubpull/main.go
+++ b/hack/alpine/hubpull/main.go
@@ -1,0 +1,314 @@
+package main
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// Docker Hub API endpoints
+	dockerRegistry = "https://registry.hub.docker.com"
+	dockerAuth     = "https://auth.docker.io/token"
+	registryV2     = "https://registry-1.docker.io/v2"
+)
+
+// ImageIndex represents a Docker image index (fat manifest)
+type ImageIndex struct {
+	SchemaVersion int    `json:"schemaVersion"`
+	MediaType     string `json:"mediaType"`
+	Manifests     []struct {
+		MediaType string `json:"mediaType"`
+		Digest    string `json:"digest"`
+		Size      int    `json:"size"`
+		Platform  struct {
+			Architecture string `json:"architecture"`
+			OS           string `json:"os"`
+			Variant      string `json:"variant,omitempty"`
+		} `json:"platform"`
+		Annotations map[string]string `json:"annotations,omitempty"`
+	} `json:"manifests"`
+}
+
+// ImageManifest represents the Docker image manifest
+type ImageManifest struct {
+	SchemaVersion int    `json:"schemaVersion"`
+	MediaType     string `json:"mediaType"`
+	Config        struct {
+		MediaType string `json:"mediaType"`
+		Size      int    `json:"size"`
+		Digest    string `json:"digest"`
+	} `json:"config"`
+	Layers []struct {
+		MediaType string `json:"mediaType"`
+		Size      int    `json:"size"`
+		Digest    string `json:"digest"`
+	} `json:"layers"`
+}
+
+func httpClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+}
+
+// getToken obtains an authentication token for Docker Hub
+func getToken(image string) (string, error) {
+	repo := image
+	if !strings.Contains(repo, "/") {
+		repo = "library/" + repo
+	}
+
+	url := fmt.Sprintf("%s?service=registry.docker.io&scope=repository:%s:pull", dockerAuth, repo)
+
+	resp, err := httpClient().Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to get token: %s", resp.Status)
+	}
+
+	var result struct {
+		Token string `json:"token"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+
+	return result.Token, nil
+}
+
+// getImageIndex gets the image index (fat manifest) for the Docker image
+func getImageIndex(image, tag, token string) (*ImageIndex, error) {
+	repo := image
+	if !strings.Contains(repo, "/") {
+		repo = "library/" + repo
+	}
+
+	url := fmt.Sprintf("%s/%s/manifests/%s", registryV2, repo, tag)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	// Accept OCI and Docker manifest formats
+	req.Header.Set("Accept", "application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json")
+
+	client := httpClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get image index: %s", resp.Status)
+	}
+
+	var index ImageIndex
+	if err := json.NewDecoder(resp.Body).Decode(&index); err != nil {
+		return nil, err
+	}
+
+	return &index, nil
+}
+
+// getManifest gets the specific manifest for an architecture from the image index
+func getManifest(image, digestOrTag, token string, architecture string) (*ImageManifest, error) {
+	repo := image
+	if !strings.Contains(repo, "/") {
+		repo = "library/" + repo
+	}
+
+	// First check if we were given a digest directly
+	if !strings.HasPrefix(digestOrTag, "sha256:") {
+		// We have a tag, get the image index first
+		index, err := getImageIndex(image, digestOrTag, token)
+		if err != nil {
+			return nil, err
+		}
+
+		// Find the manifest for the requested architecture
+		var manifestDigest string
+		for _, manifest := range index.Manifests {
+			// Skip attestation manifests
+			if manifest.Platform.Architecture == "unknown" {
+				continue
+			}
+
+			// If no architecture specified, default to amd64
+			if architecture == "" && manifest.Platform.Architecture == "amd64" {
+				manifestDigest = manifest.Digest
+				break
+			}
+
+			if architecture != "" && manifest.Platform.Architecture == architecture {
+				manifestDigest = manifest.Digest
+				break
+			}
+		}
+
+		if manifestDigest == "" {
+			if architecture == "" {
+				architecture = "amd64"
+			}
+			return nil, fmt.Errorf("no manifest found for architecture: %s", architecture)
+		}
+
+		digestOrTag = manifestDigest
+	}
+
+	// Now get the specific manifest by digest
+	url := fmt.Sprintf("%s/%s/manifests/%s", registryV2, repo, digestOrTag)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json,application/vnd.oci.image.manifest.v1+json")
+
+	client := httpClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get manifest: %s", resp.Status)
+	}
+
+	var manifest ImageManifest
+	if err := json.NewDecoder(resp.Body).Decode(&manifest); err != nil {
+		return nil, err
+	}
+
+	return &manifest, nil
+}
+
+// downloadLayer downloads a single layer from Docker Hub
+func downloadLayer(image, digest, token, outputDir string) (string, error) {
+	repo := image
+	if !strings.Contains(repo, "/") {
+		repo = "library/" + repo
+	}
+
+	url := fmt.Sprintf("%s/%s/blobs/%s", registryV2, repo, digest)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := httpClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to download layer: %s", resp.Status)
+	}
+
+	// Create output file
+	layerFile := filepath.Join(outputDir, strings.Replace(digest, "sha256:", "", 1)+".tar.gz")
+	out, err := os.Create(layerFile)
+	if err != nil {
+		return "", err
+	}
+	defer out.Close()
+
+	// Copy the layer content to the file
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return layerFile, nil
+}
+
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Println("Usage: docker-hub-downloader <image> <tag> [architecture]")
+		fmt.Println("Example: docker-hub-downloader nginx latest")
+		fmt.Println("Example with architecture: docker-hub-downloader alpine latest arm64")
+		os.Exit(1)
+	}
+
+	image := os.Args[1]
+	tag := os.Args[2]
+
+	// Optional architecture parameter
+	architecture := ""
+	if len(os.Args) >= 4 {
+		architecture = os.Args[3]
+	}
+
+	outputDir := fmt.Sprintf("%s-%s", image, tag)
+	if architecture != "" {
+		outputDir = fmt.Sprintf("%s-%s-%s", image, tag, architecture)
+	}
+
+	// Create output directory
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		fmt.Printf("Failed to create output directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Getting Docker Hub token...")
+	token, err := getToken(image)
+	if err != nil {
+		fmt.Printf("Error getting token: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Getting image manifest...")
+	manifest, err := getManifest(image, tag, token, architecture)
+	if err != nil {
+		fmt.Printf("Error getting manifest: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Image has %d layers\n", len(manifest.Layers))
+
+	var layerFiles []string
+	for i, layer := range manifest.Layers {
+		fmt.Printf("Downloading layer %d/%d: %s\n", i+1, len(manifest.Layers), layer.Digest)
+		layerFile, err := downloadLayer(image, layer.Digest, token, outputDir)
+		if err != nil {
+			fmt.Printf("Error downloading layer: %v\n", err)
+			os.Exit(1)
+		}
+		layerFiles = append(layerFiles, layerFile)
+	}
+
+	fmt.Printf("Layers downloaded to %s directory\n", outputDir)
+	fmt.Println("The layers are individual .tar.gz files that make up the Docker image.")
+
+	// Save manifest and config for informational purposes
+	manifestFile := filepath.Join(outputDir, "manifest.json")
+	manifestJSON, _ := json.MarshalIndent(manifest, "", "  ")
+	if err := os.WriteFile(manifestFile, manifestJSON, 0644); err != nil {
+		fmt.Printf("Warning: Failed to write manifest file: %v\n", err)
+	}
+
+	fmt.Println("\nTo use these layers, you would typically need to process them further into a Docker image tarball format.")
+}

--- a/wasm/assets/wanix.js
+++ b/wasm/assets/wanix.js
@@ -191,8 +191,6 @@ function setupConsoleHelpers() {
         await w.readFile("web/vm/new");
         await w.writeFile("task/1/ctl", "bind web/dom/2/data web/vm/2/ttyS0");
         await w.writeFile("task/1/ctl", "bind #alpine web/vm/2/fsys");
-        await w.writeFile("task/1/ctl", "bind web/opfs/init web/vm/2/fsys/bin/init");
-        await w.writeFile("task/1/ctl", "bind web/opfs/bin/post-dhcp web/vm/2/fsys/bin/post-dhcp");
         // await w.writeFile("task/1/ctl", "bind . web/vm/2/fsys");
         await w.writeFile("web/vm/2/ctl", "start");
     }

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -52,15 +52,15 @@ func main() {
 	root.Namespace().Bind(rw, ".", "#shell", "")
 	// root.Namespace().Bind(fskit.MemFS{}, ".", "#shell", "")
 
-	// afs, err := fetchTarballFS("/shell/alpine.tgz")
-	// if err != nil {
-	// 	log.Fatal(err)
-	// }
-	// arw := fskit.MemFS{}
-	// if err := fs.CopyFS(afs, ".", arw, "."); err != nil {
-	// 	log.Fatal(err)
-	// }
-	// root.Namespace().Bind(arw, ".", "#alpine", "")
+	afs, err := fetchTarballFS("/alpine/alpine.tgz")
+	if err != nil {
+		log.Fatal(err)
+	}
+	arw := fskit.MemFS{}
+	if err := fs.CopyFS(afs, ".", arw, "."); err != nil {
+		log.Fatal(err)
+	}
+	root.Namespace().Bind(arw, ".", "#alpine", "")
 
 	go virtio9p.Serve(root.Namespace(), inst, false)
 	api.PortResponder(inst.Get("sys"), root)


### PR DESCRIPTION
The `explore/alpine` branch is actively exploring:

- [x] process to get docker hub images for wanix vms
- [x] working alpine virtual environment
- [x] networking/internet access from virtual environment
- [ ] working apk to install packages
- [ ] benchmark go compiler performance in alpine

## hubpull

There is a proof of concept utility (`hack/alpine/hubpull`) that pulls Docker
images from Docker Hub directly without Docker. Eventually this could become a
Wanix capability that creates a mount based on the layers. For now we just use
it to fetch the `i386/alpine:latest` single layer image.

## alpine

```sh
make -C hack/alpine
```

This uses `hubpull` and `fixlinks` (changes absolute symlinks to relative) and
adds the scripts in `hack/alpine/bin` to produce `hack/alpine/alpine.tgz`. 
This is embedded and served at `/alpine/alpine.tgz`. 

After the Wanix shell is loaded, in DevTools console you can run `bootAlpine()`.
This creates another VM using the `alpine.tgz` and a new terminal over the 
existing one (whole new xterm covering viewport).

This will boot with the custom init script, setting up eth0 and DHCP using the
virtual network stack that runs with `wanix serve`. It takes a moment longer 
than the normal shell. If it doesn't, run with `bootAlpine(true)` to see 
kernel output.

## apk

Currently, running `apk update` fails due to a failed rename operation, which
should also show up in the DevTools console. 

From the debug error in the console, it seems the filesystem is not resolving
to one that supports rename. It should resolve to the `#alpine` memfs that's
mounted at `web/vm/2/fsys`, but doesn't seem to. 

Goal is to update and then install a package.

## go compiler

Any package will prove apk working, but in this exploration I want to install
the Go toolchain to see how it performs. While we can compile Go to WASI and 
run it as a wasi task, it performs very poorly. Much worse than the non-WASI
build we used in 0.2. Perhaps due to the SharedArrayBuffer hack needed for WASI.

While that's a separate issue, I'm hoping an emulated x86 compiler will be fast
enough for now.