### PR TITLE
v86: update to work with latest v86

### DIFF
--- a/external/v86/patch/starter.js
+++ b/external/v86/patch/starter.js
@@ -1001,6 +1001,40 @@ V86.prototype.eject_fda = function()
 };
 
 /**
+ * Set the image inserted in the CD-ROM drive. Can be changed at runtime, as
+ * when physically changing the CD-ROM.
+ */
+V86.prototype.set_cdrom = async function(file)
+{
+    if(file.url && !file.async)
+    {
+        load_file(file.url, {
+            done: result =>
+            {
+                this.v86.cpu.devices.cdrom.set_cdrom(new SyncBuffer(result));
+            },
+        });
+    }
+    else
+    {
+        const image = buffer_from_object(file, this.zstd_decompress_worker.bind(this));
+        image.onload = () =>
+        {
+            this.v86.cpu.devices.cdrom.set_cdrom(image);
+        };
+        await image.load();
+    }
+};
+
+/**
+ * Eject the CD-ROM.
+ */
+V86.prototype.eject_cdrom = function()
+{
+    this.v86.cpu.devices.cdrom.eject();
+};
+
+/**
  * Send a sequence of scan codes to the emulated PS2 controller. A list of
  * codes can be found at http://stanislavs.org/helppc/make_codes.html.
  * Do nothing if there is no keyboard controller.


### PR DESCRIPTION
to build with current v86, without this patch you'll see 

```
STEP 9/14: RUN PATH="${HOME}/.cargo/bin:${PATH}" make all && rm -rf closure-compiler gen lib src .cargo cargo.toml Makefile
mkdir -p closure-compiler
# don't upgrade until https://github.com/google/closure-compiler/issues/3972 is fixed
wget -nv -O closure-compiler/compiler.jar https://repo1.maven.org/maven2/com/google/javascript/closure-compiler/v20210601/closure-compiler-v20210601.jar
Connecting to repo1.maven.org (199.232.192.209:443)
saving to 'closure-compiler/compiler.jar'
compiler.jar         100% |********************************| 12.0M  0:00:00 ETA
'closure-compiler/compiler.jar' saved
mkdir -p build
ls -lh build/v86_all.js
ls: build/v86_all.js: No such file or directory
make: [Makefile:104: build/v86_all.js] Error 1 (ignored)
java -jar closure-compiler/compiler.jar \
        --js_output_file build/v86_all.js\
        --define=DEBUG=false\
        --source_map_format V3 --create_source_map '%outname%.map'\
        --generate_exports --externs src/externs.js --warning_level VERBOSE --jscomp_error accessControls --jscomp_error checkRegExp --jscomp_error checkTypes --jscomp_error checkVars --jscomp_error conformanceViolations --jscomp_error const --jscomp_error constantProperty --jscomp_error deprecated --jscomp_error deprecatedAnnotations --jscomp_error duplicateMessage --jscomp_error es5Strict --jscomp_error externsValidation --jscomp_error globalThis --jscomp_error invalidCasts --jscomp_error misplacedTypeAnnotation --jscomp_error missingProperties --jscomp_error missingReturn --jscomp_error msgDescriptions --jscomp_error nonStandardJsDocs --jscomp_error suspiciousCode --jscomp_error strictModuleDepCheck --jscomp_error typeInvalidation --jscomp_error undefinedVars --jscomp_error unknownDefines --jscomp_error visibility --use_types_for_optimization --assume_function_wrapper --summary_detail_level 3 --language_in ECMASCRIPT_2020 --language_out ECMASCRIPT_2020\
        --compilation_level ADVANCED\
        --js src/cjs.js src/const.js src/io.js src/main.js src/lib.js src/buffer.js src/ide.js src/pci.js src/floppy.js src/dma.js src/pit.js src/vga.js src/ps2.js src/rtc.js src/uart.js src/acpi.js src/apic.js src/ioapic.js src/iso9660.js src/state.js src/ne2k.js src/sb16.js src/virtio.js src/virtio_console.js src/virtio_net.js src/virtio_balloon.js src/bus.js src/log.js src/cpu.js src/elf.js src/kernel.js\
        --js lib/9p.js lib/filesystem.js lib/marshall.js\
        --js src/browser/screen.js src/browser/keyboard.js src/browser/mouse.js src/browser/speaker.js src/browser/serial.js src/browser/network.js src/browser/starter.js src/browser/worker_bus.js src/browser/dummy_screen.js src/browser/inbrowser_network.js src/browser/fake_network.js src/browser/wisp_network.js src/browser/fetch_network.js src/browser/print_stats.js src/browser/filestorage.js\
        --js src/browser/main.js
src/browser/main.js:2511:21: ERROR - [JSC_INEXISTENT_PROPERTY] Property eject_cdrom never defined on V86
  2511|             emulator.eject_cdrom();
                             ^^^^^^^^^^^

src/browser/main.js:2544:35: ERROR - [JSC_INEXISTENT_PROPERTY] Property set_cdrom never defined on V86
  2544|                     await emulator.set_cdrom({ buffer });
                                           ^^^^^^^^^
```