### PR TITLE
pipe: report buffer size as file size

### DIFF
--- a/vfs/pipe/buffer.go
+++ b/vfs/pipe/buffer.go
@@ -58,3 +58,9 @@ func (bp *Buffer) Close() error {
 	bp.dataCond.Broadcast()
 	return nil
 }
+
+func (bp *Buffer) Size() int {
+	bp.mu.Lock()
+	defer bp.mu.Unlock()
+	return bp.buffer.Len()
+}

--- a/vfs/pipe/pipe.go
+++ b/vfs/pipe/pipe.go
@@ -38,3 +38,7 @@ func (p *Port) Close() error {
 	}
 	return err2
 }
+
+func (p *Port) Size() int {
+	return p.reader.Size()
+}

--- a/vfs/pipe/portfile.go
+++ b/vfs/pipe/portfile.go
@@ -31,7 +31,7 @@ func (pf *PortFile) Close() error { return nil }
 func (pf *PortFile) Read(b []byte) (int, error) { return pf.Port.Read(b) }
 
 func (pf *PortFile) Stat() (fs.FileInfo, error) {
-	return fskit.Entry(pf.Name, fs.FileMode(0644)), nil
+	return fskit.Entry(pf.Name, fs.FileMode(0644)|fs.ModeNamedPipe, int64(pf.Port.Size())), nil
 }
 
 // Optional stream-friendly methods


### PR DESCRIPTION
The #pipe device files previously reported a static size of 0 in their file stats, which did not reflect the amount of data pending in their read buffers. This commit implements the functionality to dynamically report the current length of a pipe's read buffer as the file's size.

This was achieved by:
- Adding a thread-safe Size() method to pipe.Buffer to expose the internal buffer length.
- Exposing this size through a new method on pipe.Port.
- Updating PortFile.Stat() to call this method and pass the dynamic size to fskit.Entry, ensuring the file mode is correctly set to include fs.ModeNamedPipe.

Fixes #215