### PR TITLE
fix docker create command in shell's Makefile

### DIFF
--- a/shell/Makefile
+++ b/shell/Makefile
@@ -6,7 +6,7 @@ bundle.tgz: bundle
 bundle:
 	$(DOCKER_CMD) build -t wanix-shell-build --platform linux/386 -f Dockerfile .
 	$(DOCKER_CMD) rm -f wanix-shell-export && mkdir -p bundle
-	$(DOCKER_CMD) create --name wanix-shell-export --platform linux/386 wanix-shell-build
+	$(DOCKER_CMD) create --name wanix-shell-export --platform linux/386 wanix-shell-build noop
 	$(DOCKER_CMD) export wanix-shell-export | tar -C bundle -xf -
 	
 


### PR DESCRIPTION
make was failing in shell dir, with `docker create` complaining about missing command

```
~/wanix/shell $ make bundle

/usr/bin/docker create --name wanix-shell-export --platform linux/386 wanix-shell-build
Error response from daemon: no command specified
make: *** [Makefile:9: bundle] Error 1
```

I took the same `noop` as specified in github action:
https://github.com/tractordev/wanix/blob/main/.github/workflows/build-shell.yml#L73