### PR TITLE
fix: mac specific tar issue

### DIFF
--- a/shell/Makefile
+++ b/shell/Makefile
@@ -1,7 +1,7 @@
 DOCKER_CMD		?= $(shell command -v podman || command -v docker)
 
 bundle.tgz: bundle
-	tar -C bundle -czf bundle.tgz .
+    $(DOCKER_CMD) export wanix-shell-export | gzip > bundle.tgz
 
 bundle:
 	$(DOCKER_CMD) build -t wanix-shell-build --platform linux/386 -f Dockerfile .


### PR DESCRIPTION
mac has the bsd specific tar, which cause:
wanix.min.js:1 Uncaught (in promise) Error: Invalid PAX header data format. when loading the bundle.tgz