### PR TITLE
fix: service-worker

### DIFF
--- a/runtime/assets/wanix-sw.js
+++ b/runtime/assets/wanix-sw.js
@@ -34,7 +34,13 @@ self.addEventListener("fetch", async (event) => {
     }
 
     const req = event.request;
+    const url = new URL(req.url);
     
+    // Don't cache dynamic filesystem paths
+    if (url.pathname.startsWith("/:/")) {
+        event.respondWith(handleRequest(req));
+        return;
+    } 
     event.respondWith(cache.match(req).then(async (resp) => {
         if (resp) {
             // console.log("ServiceWorker: cached", req.url);
@@ -106,7 +112,7 @@ async function handleRequest(req) {
         
     } catch (error) {
         if (error.message === 'Timeout') {
-            listener = undefined;
+            console.warn("ServiceWorker: timeout for", req.url);
         } else {
             console.warn("ServiceWorker:", error);
         }

--- a/runtime/runtime.js
+++ b/runtime/runtime.js
@@ -19,6 +19,7 @@ export class WanixRuntime extends WanixHandle {
         this.config = config;
         this._id = Math.random().toString(36).substring(2, 15);
         this._sys = sys;
+        this._sw = new MessageChannel();
         this._ready = new Promise(resolve => this._wasmReady = resolve);
 
         if (!window.__wanix) {

--- a/web/web.go
+++ b/web/web.go
@@ -40,7 +40,6 @@ func New(k *wanix.K) fskit.MapFS {
 	}
 	if !runtime.Instance().Get("_sw").IsUndefined() {
 		webfs["sw"] = sw.Activate(runtime.Instance().Get("_sw"), k)
-		webfs["sw"] = sw.Activate(runtime.Instance().Get("_sw"), k)
 	}
 
 	k.Cap.Register("pickerfs", func(_ *cap.Resource) (cap.Mounter, error) {


### PR DESCRIPTION
I was unable to reproduce the yt wanix demo, where a new Iframe's src points to opfs via `/:/web/opfs`.
I found 2 issues, the service worker wasn't registered, and once it was it was caching the opfs file, so any change had no effect.