### PR TITLE
Reduce wanix.wasm build size by removing debug symbols.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ wasm: $(if $(WASM_DEBUG),wasm-go,) wasm-tinygo
 
 ## Build WASM module using TinyGo
 wasm-tinygo: wasi/worker/lib.js
-	tinygo build -ldflags="-X tractor.dev/wanix.Version=$(VERSION)" -target wasm -o $(DIST_DIR)/wanix.wasm ./wasm
+	tinygo build -ldflags="-X tractor.dev/wanix.Version=$(VERSION)" --no-debug -target wasm -o $(DIST_DIR)/wanix.wasm ./wasm
 	ls -lah $(DIST_DIR)/wanix.wasm
 .PHONY: wasm-tinygo
 


### PR DESCRIPTION
[`--no-debug`](https://tinygo.org/docs/reference/usage/misc-options/#:~:text=%2Dno%2Ddebug) disables outputting debug symbols, which can reduce WASM output build size significantly (>50%). Presumably debug symbols are only desired on `wanix.debug.wasm`.

Before:
```sh
~/dev/wanix/dist> ls
╭───┬────────────┬──────┬────────┬────────────────╮
│ # │    name    │ type │  size  │    modified    │
├───┼────────────┼──────┼────────┼────────────────┤
│ 0 │ wanix.wasm │ file │ 6.2 MB │ 43 seconds ago │
╰───┴────────────┴──────┴────────┴────────────────╯
```

After:

```sh
~/dev/wanix/dist> ls
╭───┬────────────┬──────┬────────┬───────────────╮
│ # │    name    │ type │  size  │   modified    │
├───┼────────────┼──────┼────────┼───────────────┤
│ 0 │ wanix.wasm │ file │ 2.9 MB │ 2 minutes ago │
╰───┴────────────┴──────┴────────┴───────────────╯
```

See https://www.fermyon.com/blog/optimizing-tinygo-wasm for other potential optimizations