### PR TITLE
Have Wanix play more nicely with a remote 9P2000.L mount

### DIFF
--- a/fs/bind/table.go
+++ b/fs/bind/table.go
@@ -136,7 +136,8 @@ func (t *Table) Route(ctx context.Context, self fs.FS, name string) (fs.FS, stri
 	for p := range b {
 		bindPaths = append(bindPaths, p)
 	}
-	for _, bindPath := range fskit.MatchPaths(bindPaths, name) {
+	matched := fskit.MatchPaths(bindPaths, name)
+	for _, bindPath := range matched {
 		refs := b[bindPath]
 		relativeName := strings.Trim(strings.TrimPrefix(name, bindPath), "/")
 		var toStat []Entry
@@ -158,6 +159,17 @@ func (t *Table) Route(ctx context.Context, self fs.FS, name string) (fs.FS, stri
 			toStat = append(toStat, ref)
 		}
 
+		// Only one bind point matches and it has a single fs: there is
+		// no union ambiguity to resolve, so skip the existence stat and
+		// let the caller's own operation surface ENOENT. The caller
+		// re-stats/opens this same path immediately, so verifying here
+		// just doubles the wire round-trips on a mounted fs (the wanix
+		// `ls` storm: every lstat cost two upstream stats, not one).
+		// With multiple candidates the stat is load-bearing — it picks
+		// the union member that actually holds the path.
+		if len(matched) == 1 && len(toStat) == 1 {
+			return toStat[0].FS, path.Join(toStat[0].Path, relativeName), nil
+		}
 		for _, ref := range toStat {
 			fullName := path.Join(ref.Path, relativeName)
 			_, err := fs.LstatContext(ctx, ref.FS, fullName)

--- a/fs/p9kit/client.go
+++ b/fs/p9kit/client.go
@@ -44,14 +44,25 @@ func walkParts(name string) []string {
 }
 
 func (fsys *FS) walk(name string) (p9.File, error) {
+	_, f, err := fsys.walkQID(name)
+	return f, err
+}
+
+// walkQID walks to name and also reports the target's qid. A
+// zero-element walk (name ".") carries no qids on the wire, but the
+// attach root is by definition a directory, so it is typed as one.
+func (fsys *FS) walkQID(name string) (p9.QID, p9.File, error) {
 	if !fs.ValidPath(name) {
-		return nil, &fs.PathError{Op: "walk", Path: name, Err: fs.ErrInvalid}
+		return p9.QID{}, nil, &fs.PathError{Op: "walk", Path: name, Err: fs.ErrInvalid}
 	}
-	_, f, err := fsys.root.Walk(walkParts(name))
+	qids, f, err := fsys.root.Walk(walkParts(name))
 	if err != nil {
-		return nil, translateError("walk", name, err)
+		return p9.QID{}, nil, translateError("walk", name, err)
 	}
-	return f, nil
+	if len(qids) == 0 {
+		return p9.QID{Type: p9.TypeDir}, f, nil
+	}
+	return qids[len(qids)-1], f, nil
 }
 
 func (fsys *FS) Open(name string) (fs.File, error) {
@@ -63,26 +74,34 @@ func (fsys *FS) OpenContext(ctx context.Context, name string) (fs.File, error) {
 		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
 	}
 
-	f, err := fsys.walk(name)
+	qid, f, err := fsys.walkQID(name)
 	if err != nil {
 		return nil, err
 	}
 
-	// Try to open with read-write first
-	_, _, err = f.Open(p9.ReadWrite)
-	if err != nil {
-		// Fallback to read-only (might be a dir or read-only file)
+	writable := false
+	if qid.Type&p9.TypeDir != 0 {
+		// Directories reject write opens; don't waste a round-trip trying.
 		_, _, err = f.Open(p9.ReadOnly)
-		if err != nil {
-			return nil, translateError("open", name, err)
+	} else {
+		// Try read-write first, falling back for read-only files.
+		_, _, err = f.Open(p9.ReadWrite)
+		if err == nil {
+			writable = true
+		} else {
+			_, _, err = f.Open(p9.ReadOnly)
 		}
+	}
+	if err != nil {
+		return nil, translateError("open", name, err)
 	}
 
 	return &remoteFile{
-		file: f,
-		root: fsys.root,
-		name: path.Base(name),
-		path: walkParts(name),
+		file:     f,
+		root:     fsys.root,
+		name:     path.Base(name),
+		path:     walkParts(name),
+		writable: writable,
 	}, nil
 }
 
@@ -391,12 +410,13 @@ func (e *lazyEntry) Type() fs.FileMode {
 func (e *lazyEntry) Info() (fs.FileInfo, error) { return e.stat() }
 
 type remoteFile struct {
-	name   string
-	file   p9.File
-	root   p9.File
-	path   []string
-	offset int64
-	iter   *fskit.DirIter
+	name     string
+	file     p9.File
+	root     p9.File
+	path     []string
+	offset   int64
+	iter     *fskit.DirIter
+	writable bool
 }
 
 func (f *remoteFile) Read(p []byte) (n int, err error) {
@@ -451,8 +471,10 @@ func (f *remoteFile) WriteAt(p []byte, off int64) (n int, err error) {
 }
 
 func (f *remoteFile) Close() error {
-	if err := f.file.FSync(); err != nil {
-		return err
+	if f.writable {
+		if err := f.file.FSync(); err != nil {
+			return err
+		}
 	}
 	return f.file.Close()
 }

--- a/fs/p9kit/client.go
+++ b/fs/p9kit/client.go
@@ -339,20 +339,12 @@ func (fsys *FS) ReadDir(name string) ([]fs.DirEntry, error) {
 	}
 	defer f.Close()
 
-	// 9P2000.L forbids walking from an open fid, so clone the directory fid and
-	// open the clone. f stays unopened to serve the per-entry walks below.
-	_, dir, err := f.Walk(nil)
-	if err != nil {
-		return nil, translateError("readdir", name, err)
-	}
-	defer dir.Close()
-
-	_, _, err = dir.Open(p9.ReadOnly)
+	_, _, err = f.Open(p9.ReadOnly)
 	if err != nil {
 		return nil, translateError("readdir", name, err)
 	}
 
-	dirents, err := dir.Readdir(0, 65535) // max uint32 breaks p9kit server
+	dirents, err := f.Readdir(0, 65535) // max uint32 breaks p9kit server
 	if err != nil {
 		return nil, translateError("readdir", name, err)
 	}
@@ -363,21 +355,40 @@ func (fsys *FS) ReadDir(name string) ([]fs.DirEntry, error) {
 		if entry.Name == "." || entry.Name == ".." {
 			continue
 		}
-		_, child, err := f.Walk([]string{entry.Name})
-		if err != nil {
-			continue
-		}
-		fi, err := fileInfo(child, entry.Name)
-		child.Close()
-		if err != nil {
-			continue // Skip entries we can't stat
-		}
-		if dirEntry, ok := fi.(fs.DirEntry); ok {
-			entries = append(entries, dirEntry)
-		}
+		childPath := path.Join(name, entry.Name)
+		entries = append(entries, &lazyEntry{
+			name: entry.Name,
+			qt:   entry.QID.Type,
+			stat: func() (fs.FileInfo, error) { return fsys.Stat(childPath) },
+		})
 	}
 	return entries, nil
 }
+
+// lazyEntry is a directory entry built from a 9P dirent: the name and
+// file type ride along with the Rreaddir qid, so a listing needs no
+// per-entry round-trips. Full attributes cost one stat, paid only if
+// Info is actually called.
+type lazyEntry struct {
+	name string
+	qt   p9.QIDType
+	stat func() (fs.FileInfo, error)
+}
+
+func (e *lazyEntry) Name() string { return e.name }
+func (e *lazyEntry) IsDir() bool  { return e.qt&p9.TypeDir != 0 }
+
+func (e *lazyEntry) Type() fs.FileMode {
+	switch {
+	case e.qt&p9.TypeDir != 0:
+		return fs.ModeDir
+	case e.qt&p9.TypeSymlink != 0:
+		return fs.ModeSymlink
+	}
+	return 0
+}
+
+func (e *lazyEntry) Info() (fs.FileInfo, error) { return e.stat() }
 
 type remoteFile struct {
 	name   string
@@ -460,14 +471,25 @@ func (f *remoteFile) ReadDir(n int) ([]fs.DirEntry, error) {
 
 			entries := make([]fs.DirEntry, 0, len(dirents))
 			for _, entry := range dirents {
-				// To fully mimic os.DirFS semantics, we can Walk and Stat, but for now just minimal implementation:
-				fi, err := fileInfo(f.file, entry.Name)
-				if err != nil {
-					continue // Skip entries we can't stat
+				// os.File.ReadDir excludes the dot entries; real 9P servers report them.
+				if entry.Name == "." || entry.Name == ".." {
+					continue
 				}
-				if dirEntry, ok := fi.(fs.DirEntry); ok {
-					entries = append(entries, dirEntry)
-				}
+				childPath := append(append([]string{}, f.path...), entry.Name)
+				entries = append(entries, &lazyEntry{
+					name: entry.Name,
+					qt:   entry.QID.Type,
+					stat: func() (fs.FileInfo, error) {
+						// f.file is open; 9P forbids walking from an open
+						// fid, so reach the entry from the root instead.
+						_, child, err := f.root.Walk(childPath)
+						if err != nil {
+							return nil, translateError("stat", entry.Name, err)
+						}
+						defer child.Close()
+						return fileInfo(child, entry.Name)
+					},
+				})
 			}
 			return entries, nil
 		})

--- a/fs/p9kit/server.go
+++ b/fs/p9kit/server.go
@@ -352,7 +352,17 @@ func (l *p9file) Readdir(offset uint64, count uint32) (dents p9.Dirents, derr er
 		return nil, err
 	}
 
-	// Use the entries already fetched from fs.ReadDir above
+	// Use the entries already fetched from fs.ReadDir above.
+	//
+	// Build each dirent's QID from the DirEntry alone — no per-entry
+	// stat. A readdir QID needs only Type and Path: the type bit rides
+	// on the DirEntry (fs.DirEntry.Type, free from the listing — for a
+	// mounted 9P fs it comes straight off the .L dirent qid), and
+	// toQid hashes the path string, ignoring FileInfo. This is
+	// identical to what info() would compute, so a later Twalk+GetAttr
+	// on the entry yields the same QID (no client-side cache thrash),
+	// but it costs zero round-trips instead of walk+getattr+clunk per
+	// entry — the "300 stats for one ls" amplifier over a slow mount.
 	for _, e := range entries {
 		cursor++
 
@@ -374,17 +384,20 @@ func (l *p9file) Readdir(offset uint64, count uint32) (dents p9.Dirents, derr er
 		}
 		seenNames[entryName] = true
 
-		localEnt := p9file{path: path.Join(l.path, e.Name()), fsys: l.fsys, vattrs: l.vattrs}
-		qid, _, err := localEnt.info()
+		ninePath, err := toQid(path.Join(l.path, entryName), nil)
 		if err != nil {
-			log.Println("p9kit: readdir info", e.Name(), err)
+			log.Println("p9kit: readdir qid", entryName, err)
 			continue
+		}
+		qid := p9.QID{
+			Type: p9.ModeFromOS(e.Type()).QIDType(),
+			Path: ninePath,
 		}
 
 		p9Ents = append(p9Ents, p9.Dirent{
 			QID:    qid,
 			Type:   qidTypeToDirentType(qid.Type), // holy hell
-			Name:   e.Name(),
+			Name:   entryName,
 			Offset: cursor,
 		})
 	}

--- a/fs/p9kit/wirecost_test.go
+++ b/fs/p9kit/wirecost_test.go
@@ -92,6 +92,124 @@ func expectCounts(t *testing.T, phase string, got map[uint8]int, want map[uint8]
 	}
 }
 
+// TestLsWireCostBaseline pins the wire cost of the client-side
+// operations the rc shell's `ls` drives through p9kit, so any
+// regression toward per-entry round-trips fails loudly:
+//
+//   - FS.ReadDir builds entries from the dirents it already holds:
+//     one walk+open+list+clunk regardless of entry count, attributes
+//     fetched only if Info() is called.
+//   - OpenContext types the target by its walk qid: directories open
+//     ReadOnly directly instead of failing a ReadWrite attempt first.
+//   - remoteFile.ReadDir types entries by their own dirent qids.
+//   - Close fsyncs only handles that were opened writable.
+//
+// Composite effect: one ls-shaped pass over 7 entries costs 28
+// messages (down from 51 with per-entry stats), and the remaining
+// floor is the caller's own per-entry Stat, not ReadDir overhead.
+func TestLsWireCostBaseline(t *testing.T) {
+	// Seven entries in the root: five files, two subdirectories.
+	backend := fskit.MapFS{
+		"f1": fskit.RawNode([]byte("x")), "f2": fskit.RawNode([]byte("x")),
+		"f3": fskit.RawNode([]byte("x")), "f4": fskit.RawNode([]byte("x")),
+		"f5":        fskit.RawNode([]byte("x")),
+		"sub/inner": fskit.RawNode([]byte("x")),
+		"sub2/deep": fskit.RawNode([]byte("x")),
+	}
+	fsys, cc, cleanup := countingSetup(t, backend)
+	defer cleanup()
+	cc.take() // discard version/attach setup traffic
+
+	t.Run("FS.ReadDir of 7 entries", func(t *testing.T) {
+		entries, err := fs.ReadDir(fsys, ".")
+		if err != nil {
+			t.Fatalf("ReadDir: %v", err)
+		}
+		if len(entries) != 7 {
+			t.Fatalf("entries = %d, want 7", len(entries))
+		}
+		expectCounts(t, "FS.ReadDir", cc.take(), map[uint8]int{
+			msgTwalk:    1, // just the directory itself — entries ride the dirents
+			msgTgetattr: 0,
+			msgTclunk:   1,
+			msgTlopen:   1,
+			msgTreaddir: 1,
+		})
+	})
+
+	t.Run("OpenContext of a directory", func(t *testing.T) {
+		f, err := fs.OpenContext(context.Background(), fsys, "sub")
+		if err != nil {
+			t.Fatalf("OpenContext: %v", err)
+		}
+		got := cc.take()
+		expectCounts(t, "OpenContext(dir)", got, map[uint8]int{
+			msgTlopen: 1, // walk qid says dir → straight to ReadOnly
+			msgTwalk:  1,
+		})
+
+		// remoteFile.ReadDir: the os.File-shaped path a WASI/gojs
+		// directory read lands on.
+		rdf, ok := f.(fs.ReadDirFile)
+		if !ok {
+			t.Fatalf("not a ReadDirFile: %T", f)
+		}
+		if _, err := rdf.ReadDir(-1); err != nil {
+			t.Fatalf("remoteFile.ReadDir: %v", err)
+		}
+		expectCounts(t, "remoteFile.ReadDir", cc.take(), map[uint8]int{
+			msgTreaddir: 1,
+			msgTgetattr: 0, // entry types come from the dirent qids
+			msgTwalk:    0,
+		})
+
+		if err := f.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		expectCounts(t, "Close", cc.take(), map[uint8]int{
+			msgTfsync: 0, // read-only handles are not fsynced
+			msgTclunk: 1,
+		})
+	})
+
+	t.Run("ls-shaped composite", func(t *testing.T) {
+		// The syscall sequence u-root ls's filepath.Walk drives for a
+		// non-recursive listing: lstat the dir, list it, lstat every
+		// entry. (The WASI shim's 1s readdir cache multiplies the
+		// whole block over slow links — wasi/wanix.ts — which is not
+		// reachable from Go; this pins the per-pass floor.)
+		if _, err := fs.Stat(fsys, "."); err != nil {
+			t.Fatal(err)
+		}
+		entries, err := fs.ReadDir(fsys, ".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, e := range entries {
+			if _, err := fs.Stat(fsys, e.Name()); err != nil {
+				t.Fatal(err)
+			}
+		}
+		got := cc.take()
+		total := 0
+		for _, n := range got {
+			total += n
+		}
+		// Seven entries cost 28 messages per listing pass: Stat(dir)=3 +
+		// ReadDir=4 (walk+open+list+clunk) + 7×Stat(entry)=21. The
+		// per-entry Stats are the caller's own (filepath.Walk lstats
+		// everything); ReadDir itself adds no per-entry traffic.
+		if total != 28 {
+			t.Errorf("composite ls total = %d messages, want 28 (was 51 before the listing fixes)", total)
+		}
+		expectCounts(t, "composite", got, map[uint8]int{
+			msgTgetattr: 8, // dir + 7 in per-entry Stat; none from ReadDir
+			msgTwalk:    9,
+			msgTclunk:   9,
+		})
+	})
+}
+
 // TestServerReaddirWireCost pins the wire cost of the path the rc
 // shell actually drives: a p9kit SERVER fronting a namespace whose
 // directory is a p9kit CLIENT mount (the `3ds`-style relay mount).
@@ -230,5 +348,19 @@ func TestNSReadDirWireCost(t *testing.T) {
 	got := cc.take()
 	if got[msgTgetattr] > 1 {
 		t.Errorf("namespace ReadDir issued %d getattrs — some layer is statting every entry again", got[msgTgetattr])
+	}
+
+	// What filepath.Walk-style callers (ls -l, tab completion) then
+	// do: lstat every entry. Each lstat must cost ONE upstream stat
+	// (walk+getattr+clunk): with a single bind candidate there is no
+	// union ambiguity, so bind.Route adds no existence stat of its own.
+	for _, e := range entries {
+		if _, err := fs.Lstat(ns, "dev/"+e.Name()); err != nil {
+			t.Fatalf("Lstat %q: %v", e.Name(), err)
+		}
+	}
+	ls := cc.take()
+	if ls[msgTgetattr] != 10 {
+		t.Errorf("10 lstats issued %d getattrs, want 10 (one per entry)", ls[msgTgetattr])
 	}
 }

--- a/fs/p9kit/wirecost_test.go
+++ b/fs/p9kit/wirecost_test.go
@@ -1,0 +1,234 @@
+package p9kit
+
+import (
+	"context"
+	"encoding/binary"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/hugelgupf/p9/p9"
+	"tractor.dev/wanix/fs"
+	"tractor.dev/wanix/fs/fskit"
+	"tractor.dev/wanix/fs/vfs"
+)
+
+// 9P2000.L T-message types counted by the wire-cost baselines.
+const (
+	msgTlopen   = 12
+	msgTgetattr = 24
+	msgTreaddir = 40
+	msgTfsync   = 50
+	msgTwalk    = 110
+	msgTclunk   = 120
+)
+
+// countingConn tallies the 9P T-messages the client writes. The p9
+// client emits one message across several Write calls, so frames are
+// reassembled from the byte stream by their size[4] header before the
+// type byte at offset 4 is counted.
+type countingConn struct {
+	net.Conn
+	mu     sync.Mutex
+	buf    []byte
+	counts map[uint8]int
+}
+
+func (cc *countingConn) Write(p []byte) (int, error) {
+	cc.mu.Lock()
+	cc.buf = append(cc.buf, p...)
+	for len(cc.buf) >= 4 {
+		size := binary.LittleEndian.Uint32(cc.buf)
+		if size < 7 || uint32(len(cc.buf)) < size {
+			break
+		}
+		cc.counts[cc.buf[4]]++
+		cc.buf = cc.buf[size:]
+	}
+	cc.mu.Unlock()
+	return cc.Conn.Write(p)
+}
+
+// take returns the counts accumulated since the last take and resets.
+func (cc *countingConn) take() map[uint8]int {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	got := cc.counts
+	cc.counts = map[uint8]int{}
+	return got
+}
+
+func countingSetup(t *testing.T, backend fs.FS) (fs.FS, *countingConn, func()) {
+	t.Helper()
+	a, b := net.Pipe()
+	srv := p9.NewServer(Attacher(backend))
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.Handle(a, a)
+	}()
+	cc := &countingConn{Conn: b, counts: map[uint8]int{}}
+	fsys, err := ClientFS(cc, "")
+	if err != nil {
+		t.Fatalf("ClientFS: %v", err)
+	}
+	cleanup := func() {
+		b.Close()
+		a.Close()
+		<-done
+	}
+	return fsys, cc, cleanup
+}
+
+func expectCounts(t *testing.T, phase string, got map[uint8]int, want map[uint8]int) {
+	t.Helper()
+	names := map[uint8]string{
+		msgTlopen: "Tlopen", msgTgetattr: "Tgetattr", msgTreaddir: "Treaddir",
+		msgTfsync: "Tfsync", msgTwalk: "Twalk", msgTclunk: "Tclunk",
+	}
+	for typ, n := range want {
+		if got[typ] != n {
+			t.Errorf("%s: %s = %d, want %d", phase, names[typ], got[typ], n)
+		}
+	}
+}
+
+// TestServerReaddirWireCost pins the wire cost of the path the rc
+// shell actually drives: a p9kit SERVER fronting a namespace whose
+// directory is a p9kit CLIENT mount (the `3ds`-style relay mount).
+// This composition — not FS.ReadDir in isolation — is what a gojs
+// task's `ls` hits, and it was the real "300 stats for one ls"
+// amplifier: server.Readdir used to stat EVERY entry through the mount
+// (walk+getattr+clunk each) to fill in dirent QIDs, on top of the
+// listing itself.
+//
+// The fix builds each dirent QID from the DirEntry alone (type from
+// the .L dirent, path from a string hash), so a k-entry directory
+// costs one client listing and ZERO per-entry round-trips. If someone
+// reintroduces a per-entry stat here, Tgetattr goes back above zero
+// and this fails.
+func TestServerReaddirWireCost(t *testing.T) {
+	backend := fskit.MapFS{
+		"f1": fskit.RawNode([]byte("x")), "f2": fskit.RawNode([]byte("x")),
+		"f3": fskit.RawNode([]byte("x")), "f4": fskit.RawNode([]byte("x")),
+		"f5":        fskit.RawNode([]byte("x")),
+		"sub/inner": fskit.RawNode([]byte("x")),
+		"sub2/deep": fskit.RawNode([]byte("x")),
+	}
+	fsys, cc, cleanup := countingSetup(t, backend)
+	defer cleanup()
+	cc.take() // discard version/attach setup traffic
+
+	// The server p9file that fronts the mounted client fs to a task.
+	srv := &p9file{path: ".", fsys: fsys}
+	dents, err := srv.Readdir(0, 100)
+	if err != nil {
+		t.Fatalf("server Readdir: %v", err)
+	}
+	if len(dents) != 7 {
+		t.Fatalf("dents = %d, want 7", len(dents))
+	}
+
+	// One client listing, no per-entry stats: walk+lopen+readdir+clunk.
+	got := cc.take()
+	if got[msgTgetattr] != 0 {
+		t.Errorf("server Readdir issued %d Tgetattr over the mount — per-entry stat is back (the storm)", got[msgTgetattr])
+	}
+	total := 0
+	for _, n := range got {
+		total += n
+	}
+	if total > 6 {
+		t.Errorf("server Readdir wire cost = %d messages, want <=6 (one listing, no per-entry traffic); got %v", total, got)
+	}
+
+	// Dirents must still be correctly typed from the DirEntry alone.
+	dt := map[string]p9.QIDType{}
+	for _, d := range dents {
+		dt[d.Name] = d.Type
+	}
+	if dt["sub"] != p9.QIDType(4) { // DT_DIR
+		t.Errorf("sub dirent type = %d, want 4 (DT_DIR)", dt["sub"])
+	}
+	if dt["f1"] != p9.QIDType(8) { // DT_REG
+		t.Errorf("f1 dirent type = %d, want 8 (DT_REG)", dt["f1"])
+	}
+}
+
+// TestRemoteFileReadDirLabelsEntries covers the correctness half of
+// the listing fix: remoteFile.ReadDir used to stat the DIRECTORY's own
+// fid for every entry, so each entry reported the directory's
+// attributes — a plain file claimed IsDir()==true. Entries are now
+// typed by their own dirent qid, and Info() walks to the entry itself.
+func TestRemoteFileReadDirLabelsEntries(t *testing.T) {
+	backend := fskit.MapFS{"sub/inner": fskit.RawNode([]byte("hello"))}
+	fsys, cc, cleanup := countingSetup(t, backend)
+	defer cleanup()
+
+	f, err := fs.OpenContext(context.Background(), fsys, "sub")
+	if err != nil {
+		t.Fatalf("OpenContext: %v", err)
+	}
+	defer f.Close()
+	entries, err := f.(fs.ReadDirFile).ReadDir(-1)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "inner" {
+		t.Fatalf("entries = %v", entries)
+	}
+	if entries[0].IsDir() {
+		t.Fatalf("inner is a plain file but IsDir() = true (the pre-fix mislabel)")
+	}
+	if entries[0].Type() != 0 {
+		t.Fatalf("Type() = %v, want 0 (regular file)", entries[0].Type())
+	}
+
+	// Info() is lazy: it walks to the entry itself and stats it there,
+	// on demand, rather than mislabeling it up front.
+	cc.take()
+	fi, err := entries[0].Info()
+	if err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if fi.IsDir() || fi.Size() != 5 {
+		t.Fatalf("Info = dir:%v size:%d, want plain 5-byte file", fi.IsDir(), fi.Size())
+	}
+	expectCounts(t, "lazy Info", cc.take(), map[uint8]int{
+		msgTwalk:    1,
+		msgTgetattr: 1,
+		msgTclunk:   1,
+	})
+}
+
+// TestNSReadDirWireCost drives a directory read the way api/readdir.go
+// does for a task's `ls`: through a vfs.NS namespace with a 9P client
+// mount bound into it. Reading a k-entry directory must cost one
+// listing, not k stats: the namespace keeps entries lazy (vfs) and the
+// client builds them from dirents, so no layer re-stats each entry.
+func TestNSReadDirWireCost(t *testing.T) {
+	backend := fskit.MapFS{}
+	subs := []string{"audio", "camera", "display", "input", "ir", "led", "nfc", "power", "sd", "system"}
+	for _, s := range subs {
+		backend["dev/"+s+"/a"] = fskit.RawNode([]byte("x"))
+	}
+	client, cc, cleanup := countingSetup(t, backend)
+	defer cleanup()
+
+	ns := vfs.New(context.Background())
+	if err := ns.Bind(client, ".", ".", vfs.BindReplace); err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	cc.take() // discard setup + bind traffic
+
+	entries, err := fs.ReadDir(ns, "dev")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 10 {
+		t.Fatalf("entries = %d, want 10", len(entries))
+	}
+	got := cc.take()
+	if got[msgTgetattr] > 1 {
+		t.Errorf("namespace ReadDir issued %d getattrs — some layer is statting every entry again", got[msgTgetattr])
+	}
+}

--- a/fs/vfs/vfs.go
+++ b/fs/vfs/vfs.go
@@ -187,13 +187,13 @@ func (ns *NS) OpenContext(ctx context.Context, name string) (fs.File, error) {
 					log.Println("readdir error:", err)
 					return nil, err
 				}
-				for _, entry := range entries {
-					ei, err := entry.Info()
-					if err != nil {
-						return nil, err
-					}
-					dirEntries = append(dirEntries, fskit.RawNode(ei))
-				}
+				// Keep entries lazy: calling entry.Info() here would
+				// stat every child over the wire on every readdir (a
+				// p9kit mount turns that into walk+getattr+clunk per
+				// entry — the wanix `ls` storm). DirEntry.Name()/Type()
+				// suffice for merge, dedup, and the readdir reply;
+				// callers pay Info() only if they actually need it.
+				dirEntries = append(dirEntries, entries...)
 			} else {
 				if file, err := fs.OpenContext(ctx, ref.FS, ref.Path); err == nil {
 					return file, nil
@@ -224,13 +224,8 @@ func (ns *NS) OpenContext(ctx context.Context, name string) (fs.File, error) {
 					log.Println("readdir error:", err)
 					return nil, err
 				}
-				for _, entry := range entries {
-					ei, err := entry.Info()
-					if err != nil {
-						return nil, err
-					}
-					dirEntries = append(dirEntries, fskit.RawNode(ei))
-				}
+				// Lazy: see the note in the direct-binding branch above.
+				dirEntries = append(dirEntries, entries...)
 			} else {
 				if file, err := fs.OpenContext(ctx, ref.FS, relativePath); err == nil {
 					return file, nil

--- a/rc/ls/ls.go
+++ b/rc/ls/ls.go
@@ -71,6 +71,41 @@ func (c *command) listName(stringer lsfmt.Stringer, d string, prefix bool, f fla
 	var files []file
 	resolvedPath := c.ResolvePath(d)
 
+	// Fast path: a plain listing needs only names. filepath.Walk below
+	// lstats every entry to decide recursion — over a 9P mount that
+	// turns `ls` into a per-entry stat storm (Linux's ls trusts readdir
+	// and stats nothing). Readdirnames is the stat-free primitive: on
+	// js/wasm the readdir syscall carries no d_type, so os.ReadDir's
+	// DirEntry.Type would force an lstat per entry (os.file_unix
+	// newUnixDirent), but Readdirnames only collects names. Engage
+	// whenever no flag needs per-entry metadata; any error (e.g. a
+	// non-directory argument) falls through to the unchanged Walk path.
+	if !f.long && !f.size && !f.classify && !f.recurse && !f.directory {
+		if dirf, err := os.Open(resolvedPath); err == nil {
+			names, rerr := dirf.Readdirnames(-1)
+			dirf.Close()
+			if rerr == nil {
+				sort.Strings(names)
+				if prefix {
+					if f.quoted {
+						fmt.Fprintf(c.Stdout, "%q:\n", d)
+					} else {
+						fmt.Fprintf(c.Stdout, "%v:\n", d)
+					}
+				}
+				// The Walk path lists the directory itself as "."
+				// (shown only with -a); match that.
+				if f.all {
+					c.printFile(stringer, file{lsfi: lsfmt.FileInfo{Name: "."}}, f)
+				}
+				for _, name := range names {
+					c.printFile(stringer, file{lsfi: lsfmt.FileInfo{Name: name}}, f)
+				}
+				return
+			}
+		}
+	}
+
 	filepath.Walk(resolvedPath, func(path string, osfi os.FileInfo, err error) error {
 		file := file{path: path, osfi: osfi}
 		if osfi != nil && !errors.Is(err, os.ErrNotExist) {


### PR DESCRIPTION
This change allows wanix to connect to a remote 9P2000.L mount with a minimum of 9P messages (stat in particular)

This makes wanix more responsive. With this change, adding a line like this:

```
<wanix-bind type="import" dst="3ds" src="wss://9p.fly.dev/abc123"></wanix-bind>
```

Will mount the remote filesystem and allow you to edit it without waiting too long.

Let me know if I should annotate this PR to make it more clear what is going on.