### PR TITLE
rc: add watch command

### DIFF
--- a/elements/term.js
+++ b/elements/term.js
@@ -156,7 +156,14 @@ export class TerminalElement extends WanixElement {
                 }
                 // may add line discipline as mode to terminals but for now we
                 // do as plan 9 and handle it here in "userspace"
-                if (data === '\r') {
+                if (data === '\x03') {          // Ctrl-C
+                    buffer = '';
+                    this._term.write('^C\r\n');
+                    if (this.#writer) {
+                        // send ETX now; newline wakes line-oriented readers
+                        this.#writer.write(encoder.encode('\x03\n'));
+                    }
+                } else if (data === '\r') {
                     this._term.write('\r\n');           // echo newline
                     if (this.#writer) {
                         this.#writer.write(encoder.encode(buffer+"\n"));

--- a/rc/README.md
+++ b/rc/README.md
@@ -111,7 +111,7 @@ It also bundles utility commands. Current bundled commands include:
 - `base64`, `cat`, `chmod`, `cp`, `env`, `find`
 - `gzip`, `gzcat`, `gunzip`
 - `ls`, `mkdir`, `mv`, `rm`
-- `shasum`, `tar`, `touch`, `xargs`
+- `shasum`, `tar`, `touch`, `watch`, `xargs`
 
 Note: bundled commands are not shell "builtins"; they are just commands embedded
 in rc similar to busybox.

--- a/rc/coreutils.go
+++ b/rc/coreutils.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 
@@ -30,6 +31,7 @@ import (
 	"tractor.dev/wanix/rc/ls"
 	"tractor.dev/wanix/rc/stat"
 	"tractor.dev/wanix/rc/unbind"
+	"tractor.dev/wanix/rc/watch"
 	"tractor.dev/wanix/rc/write"
 )
 
@@ -63,9 +65,24 @@ var coreutilsCommands = map[string]func() core.Command{
 	"write":   func() core.Command { return write.New() },
 }
 
+func newCoreutilsCommand(name string, execute commandExecutor) (core.Command, bool) {
+	if name == "watch" {
+		return watch.New(execute), true
+	}
+	newCommand, ok := coreutilsCommands[name]
+	if !ok {
+		return nil, false
+	}
+	return newCommand(), true
+}
+
 func urootCoreutilsMiddleware() func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc {
 	return func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc {
-		return func(ctx context.Context, args []string) error {
+		var execute interp.ExecHandlerFunc
+		executeCommand := func(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+			return execute(withExecIO(ctx, stdin, stdout, stderr), args)
+		}
+		execute = func(ctx context.Context, args []string) error {
 			if len(args) == 0 {
 				return next(ctx, args)
 			}
@@ -73,14 +90,14 @@ func urootCoreutilsMiddleware() func(next interp.ExecHandlerFunc) interp.ExecHan
 				return runEnvCommand(ctx, args[1:], next)
 			}
 
-			newCmd, ok := coreutilsCommands[args[0]]
+			cmd, ok := newCoreutilsCommand(args[0], executeCommand)
 			if !ok {
 				return next(ctx, args)
 			}
 
 			hc := interp.HandlerCtx(ctx)
-			cmd := newCmd()
-			cmd.SetIO(hc.Stdin, hc.Stdout, hc.Stderr)
+			stdin, stdout, stderr := ioForExec(ctx, hc)
+			cmd.SetIO(stdin, stdout, stderr)
 			cmd.SetWorkingDir(hc.Dir)
 			cmd.SetLookupEnv(func(key string) (string, bool) {
 				v := hc.Env.Get(key)
@@ -95,16 +112,17 @@ func urootCoreutilsMiddleware() func(next interp.ExecHandlerFunc) interp.ExecHan
 				if name == rcBindCmd {
 					name = "bind"
 				}
-				fmt.Fprintf(hc.Stderr, "rc: %s: %v\n", name, err)
+				fmt.Fprintf(stderr, "rc: %s: %v\n", name, err)
 				return interp.ExitStatus(1)
 			}
 			return nil
 		}
+		return execute
 	}
 }
 
 func bundledCommandNames() []string {
-	names := make([]string, 0, len(coreutilsCommands)+1)
+	names := make([]string, 0, len(coreutilsCommands)+2)
 	for name := range coreutilsCommands {
 		if name == rcBindCmd {
 			names = append(names, "bind")
@@ -112,13 +130,14 @@ func bundledCommandNames() []string {
 		}
 		names = append(names, name)
 	}
-	names = append(names, "env")
+	names = append(names, "env", "watch")
 	sort.Strings(names)
 	return names
 }
 
 func runEnvCommand(ctx context.Context, args []string, next interp.ExecHandlerFunc) error {
 	hc := interp.HandlerCtx(ctx)
+	_, stdout, _ := ioForExec(ctx, hc)
 	env := map[string]string{}
 	hc.Env.Each(func(name string, vr expand.Variable) bool {
 		// We intentionally include all set vars available via interp env.
@@ -181,7 +200,7 @@ func runEnvCommand(ctx context.Context, args []string, next interp.ExecHandlerFu
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		fmt.Fprintf(hc.Stdout, "%s=%s\n", k, env[k])
+		fmt.Fprintf(stdout, "%s=%s\n", k, env[k])
 	}
 	return nil
 }

--- a/rc/execio.go
+++ b/rc/execio.go
@@ -1,0 +1,37 @@
+package rc
+
+import (
+	"context"
+	"io"
+
+	"mvdan.cc/sh/v3/interp"
+)
+
+// commandExecutor runs a command through rc's normal dispatcher with the
+// supplied standard streams.
+type commandExecutor func(context.Context, []string, io.Reader, io.Writer, io.Writer) error
+
+type execIO struct {
+	stdin  io.Reader
+	stdout io.Writer
+	stderr io.Writer
+}
+
+type execIOKey struct{}
+
+// withExecIO carries scoped streams through mvdan's ExecHandlerFunc. mvdan's
+// HandlerContext key is private, so callers cannot replace it directly.
+func withExecIO(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer) context.Context {
+	return context.WithValue(ctx, execIOKey{}, execIO{
+		stdin:  stdin,
+		stdout: stdout,
+		stderr: stderr,
+	})
+}
+
+func ioForExec(ctx context.Context, hc interp.HandlerContext) (io.Reader, io.Writer, io.Writer) {
+	if streams, ok := ctx.Value(execIOKey{}).(execIO); ok {
+		return streams.stdin, streams.stdout, streams.stderr
+	}
+	return hc.Stdin, hc.Stdout, hc.Stderr
+}

--- a/rc/execio_test.go
+++ b/rc/execio_test.go
@@ -1,0 +1,113 @@
+//go:build !js
+
+package rc
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"mvdan.cc/sh/v3/expand"
+	"mvdan.cc/sh/v3/interp"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+func TestExecIO(t *testing.T) {
+	tests := []struct {
+		name             string
+		source           string
+		wantStdout       string
+		wantCaptured     string
+		capturedContains string
+		wantErr          bool
+	}{
+		{
+			name:       "default output",
+			source:     "cat <<'EOF'\nterminal\nEOF",
+			wantStdout: "terminal\n",
+		},
+		{
+			name:         "captured input and output",
+			source:       "capture cat",
+			wantCaptured: "captured input\n",
+		},
+		{
+			name:             "captured env",
+			source:           "capture env",
+			capturedContains: "EXECIO_TEST=value\n",
+		},
+		{
+			name:             "captured external error",
+			source:           "capture command-that-does-not-exist",
+			capturedContains: "rc: command-that-does-not-exist:",
+			wantErr:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr, captured bytes.Buffer
+			runner := newExecIOTestRunner(t, &stdout, &stderr, &captured)
+			parser := syntax.NewParser()
+			err := runSource(
+				context.Background(),
+				runner,
+				parser,
+				"<test>",
+				strings.NewReader(tt.source+"\n"),
+			)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("runSource() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got := stdout.String(); got != tt.wantStdout {
+				t.Fatalf("stdout = %q, want %q", got, tt.wantStdout)
+			}
+			if got := stderr.String(); got != "" {
+				t.Fatalf("stderr = %q, want empty", got)
+			}
+			if got := captured.String(); got != tt.wantCaptured &&
+				(tt.capturedContains == "" || !strings.Contains(got, tt.capturedContains)) {
+				t.Fatalf("captured output = %q, want %q or containing %q", got, tt.wantCaptured, tt.capturedContains)
+			}
+		})
+	}
+}
+
+func newExecIOTestRunner(
+	t *testing.T,
+	stdout,
+	stderr,
+	captured *bytes.Buffer,
+) *interp.Runner {
+	t.Helper()
+
+	captureMiddleware := func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc {
+		return func(ctx context.Context, args []string) error {
+			if len(args) > 0 && args[0] == "capture" {
+				return next(withExecIO(
+					ctx,
+					strings.NewReader("captured input\n"),
+					captured,
+					captured,
+				), args[1:])
+			}
+			return next(ctx, args)
+		}
+	}
+
+	runner, err := interp.New(
+		interp.Dir(t.TempDir()),
+		interp.Env(expand.ListEnviron("EXECIO_TEST=value")),
+		interp.StdIO(strings.NewReader(""), stdout, stderr),
+		interp.ExecHandlers(
+			captureMiddleware,
+			urootCoreutilsMiddleware(),
+			wanixExecMiddleware(),
+		),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return runner
+}

--- a/rc/shell.go
+++ b/rc/shell.go
@@ -85,6 +85,7 @@ func runREPL(ctx context.Context, r *interp.Runner, parser *syntax.Parser, stdin
 			return nil
 		}
 		line := scanner.Text()
+		line = lineAfterInterrupt(line)
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
@@ -102,6 +103,13 @@ func runREPL(ctx context.Context, r *interp.Runner, parser *syntax.Parser, stdin
 	}
 }
 
+func lineAfterInterrupt(line string) string {
+	if interrupt := strings.LastIndexByte(line, '\x03'); interrupt >= 0 {
+		return line[interrupt+1:]
+	}
+	return line
+}
+
 func runSource(ctx context.Context, r *interp.Runner, parser *syntax.Parser, name string, src io.Reader) error {
 	prog, err := parser.Parse(src, name)
 	if err != nil {
@@ -114,6 +122,10 @@ func wanixExecMiddleware() func(next interp.ExecHandlerFunc) interp.ExecHandlerF
 	return func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc {
 		return func(ctx context.Context, args []string) error {
 			hc := interp.HandlerCtx(ctx)
+			stdin, stdout, stderr := ioForExec(ctx, hc)
+			hc.Stdin = stdin
+			hc.Stdout = stdout
+			hc.Stderr = stderr
 			if len(args) == 0 {
 				return next(ctx, args)
 			}

--- a/rc/shell_test.go
+++ b/rc/shell_test.go
@@ -1,0 +1,24 @@
+package rc
+
+import "testing"
+
+func TestLineAfterInterrupt(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{name: "no interrupt", line: "echo hello", want: "echo hello"},
+		{name: "idle interrupt", line: "\x03", want: ""},
+		{name: "input after interrupt", line: "discarded\x03echo hello", want: "echo hello"},
+		{name: "last interrupt wins", line: "\x03old\x03new", want: "new"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := lineAfterInterrupt(tt.line); got != tt.want {
+				t.Fatalf("lineAfterInterrupt(%q) = %q, want %q", tt.line, got, tt.want)
+			}
+		})
+	}
+}

--- a/rc/watch/watch.go
+++ b/rc/watch/watch.go
@@ -1,0 +1,221 @@
+// Copyright 2015-2021 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package watch periodically executes a command.
+//
+// This implementation is adapted from u-root's cmds/exp/watch command. Instead
+// of os/exec, it uses an injected dispatcher so it works inside Wanix's
+// browser-hosted rc shell.
+package watch
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/u-root/u-root/pkg/core"
+	"github.com/u-root/u-root/pkg/uroot/unixflag"
+)
+
+const defaultInterval = int64(2)
+
+type execFunc func(context.Context, []string, io.Reader, io.Writer, io.Writer) error
+type waitFunc func(context.Context, time.Duration) bool
+
+type command struct {
+	core.Base
+	exec execFunc
+	wait waitFunc
+}
+
+// New creates a new watch command that invokes commands through exec.
+func New(exec func(context.Context, []string, io.Reader, io.Writer, io.Writer) error) core.Command {
+	return newCommand(exec, waitForInterval)
+}
+
+func newCommand(exec execFunc, wait waitFunc) *command {
+	c := &command{
+		exec: exec,
+		wait: wait,
+	}
+	c.Init()
+	return c
+}
+
+func (c *command) Run(args ...string) error {
+	return c.RunContext(context.Background(), args...)
+}
+
+func (c *command) RunContext(ctx context.Context, args ...string) error {
+	var showDifferences, noTitle bool
+	var seconds int64
+
+	fs := flag.NewFlagSet("watch", flag.ContinueOnError)
+	fs.SetOutput(c.Stderr)
+	fs.BoolVar(&showDifferences, "d", false, "highlight changes between updates")
+	fs.BoolVar(&noTitle, "t", false, "do not print header")
+	fs.Int64Var(&seconds, "n", defaultInterval, "loop period in seconds")
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), "Usage: watch [-d] [-n SEC] [-t] PROG [ARGS...]")
+		fmt.Fprintln(fs.Output(), "Run PROG periodically")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(unixflag.ArgsToGoArgs(args)); err != nil {
+		return err
+	}
+	commandArgs := fs.Args()
+	if len(commandArgs) == 0 {
+		fs.Usage()
+		return nil
+	}
+	if c.exec == nil {
+		return fmt.Errorf("command dispatcher is not configured")
+	}
+
+	commandCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go cancelOnInterrupt(c.Stdin, cancel)
+
+	intervalSeconds := seconds
+	if intervalSeconds <= 0 {
+		intervalSeconds = defaultInterval
+	}
+	interval := time.Duration(intervalSeconds) * time.Second
+
+	var currentOutput bytes.Buffer
+	commandStdin := strings.NewReader("")
+	var previousOutput string
+	havePreviousOutput := false
+	for {
+		if commandCtx.Err() != nil {
+			return nil
+		}
+
+		currentOutput.Reset()
+		_ = c.exec(commandCtx, commandArgs, commandStdin, &currentOutput, &currentOutput)
+		if commandCtx.Err() != nil {
+			return nil
+		}
+
+		c.drawHeader(commandArgs, intervalSeconds, noTitle)
+		if showDifferences {
+			output := currentOutput.String()
+			if havePreviousOutput {
+				fmt.Fprint(c.Stdout, highlightChanges(previousOutput, output))
+			} else {
+				fmt.Fprint(c.Stdout, output)
+			}
+			previousOutput = output
+			havePreviousOutput = true
+		} else {
+			_, _ = currentOutput.WriteTo(c.Stdout)
+		}
+
+		if !c.wait(commandCtx, interval) {
+			return nil
+		}
+	}
+}
+
+func (c *command) drawHeader(commandArgs []string, intervalSeconds int64, noTitle bool) {
+	fmt.Fprint(c.Stdout, "\033[0;0H\033[J")
+	if !noTitle {
+		fmt.Fprintf(c.Stdout, "Every %d : %v \n\n", intervalSeconds, commandArgs)
+	}
+}
+
+func highlightChanges(previous, current string) string {
+	if strings.ContainsRune(previous, '\x1b') || strings.ContainsRune(current, '\x1b') {
+		return current
+	}
+
+	previousLines := strings.Split(previous, "\n")
+	currentLines := strings.Split(current, "\n")
+	lineCount := max(len(previousLines), len(currentLines))
+	highlighted := make([]string, lineCount)
+	for i := range lineCount {
+		var previousLine, currentLine string
+		if i < len(previousLines) {
+			previousLine = previousLines[i]
+		}
+		if i < len(currentLines) {
+			currentLine = currentLines[i]
+		}
+		highlighted[i] = highlightLine(previousLine, currentLine)
+	}
+	return strings.Join(highlighted, "\n")
+}
+
+func highlightLine(previous, current string) string {
+	previousRunes := []rune(previous)
+	currentRunes := []rune(current)
+	width := max(len(previousRunes), len(currentRunes))
+
+	var out strings.Builder
+	highlighting := false
+	for i := range width {
+		r := ' '
+		if i < len(currentRunes) {
+			r = currentRunes[i]
+		}
+		changed := i >= len(previousRunes) || i >= len(currentRunes) || previousRunes[i] != r
+		if changed != highlighting {
+			if changed {
+				out.WriteString("\x1b[7m")
+			} else {
+				out.WriteString("\x1b[0m")
+			}
+			highlighting = changed
+		}
+		out.WriteRune(r)
+	}
+	if highlighting {
+		out.WriteString("\x1b[0m")
+	}
+	return out.String()
+}
+
+func cancelOnInterrupt(stdin io.Reader, cancel context.CancelFunc) {
+	if stdin == nil {
+		return
+	}
+
+	buf := make([]byte, 64)
+	interrupted := false
+	for {
+		n, err := stdin.Read(buf)
+		for _, b := range buf[:n] {
+			if b == '\x03' {
+				interrupted = true
+			}
+			if interrupted && b == '\n' {
+				cancel()
+				return
+			}
+		}
+		if err != nil {
+			if interrupted {
+				cancel()
+			}
+			return
+		}
+	}
+}
+
+func waitForInterval(ctx context.Context, interval time.Duration) bool {
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}

--- a/rc/watch/watch_test.go
+++ b/rc/watch/watch_test.go
@@ -1,0 +1,276 @@
+package watch
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunsImmediatelyAndRepeats(t *testing.T) {
+	var calls [][]string
+	var waits []time.Duration
+	waitCount := 0
+	var stdout bytes.Buffer
+	cmd := newCommand(
+		func(_ context.Context, args []string, commandStdin io.Reader, commandStdout, commandStderr io.Writer) error {
+			calls = append(calls, append([]string(nil), args...))
+			input, err := io.ReadAll(commandStdin)
+			if err != nil {
+				return err
+			}
+			if len(input) != 0 {
+				t.Fatalf("command stdin = %q, want EOF", input)
+			}
+			if _, err := io.WriteString(commandStdout, "stdout\n"); err != nil {
+				return err
+			}
+			if _, err := io.WriteString(commandStderr, "stderr\n"); err != nil {
+				return err
+			}
+			return nil
+		},
+		func(_ context.Context, interval time.Duration) bool {
+			waits = append(waits, interval)
+			waitCount++
+			return waitCount == 1
+		},
+	)
+	cmd.SetIO(strings.NewReader("terminal input"), &stdout, &bytes.Buffer{})
+
+	if err := cmd.RunContext(context.Background(), "-n", "5", "ls", "-l"); err != nil {
+		t.Fatalf("RunContext() error = %v", err)
+	}
+
+	wantCalls := [][]string{{"ls", "-l"}, {"ls", "-l"}}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("calls = %#v, want %#v", calls, wantCalls)
+	}
+	wantWaits := []time.Duration{5 * time.Second, 5 * time.Second}
+	if !reflect.DeepEqual(waits, wantWaits) {
+		t.Fatalf("waits = %#v, want %#v", waits, wantWaits)
+	}
+	if got := stdout.String(); strings.Count(got, "\033[0;0H\033[J") != 2 {
+		t.Fatalf("clear sequence count = %d, want 2; output %q", strings.Count(got, "\033[0;0H\033[J"), got)
+	}
+	if got := stdout.String(); strings.Count(got, "Every 5 : [ls -l]") != 2 {
+		t.Fatalf("header count = %d, want 2; output %q", strings.Count(got, "Every 5 : [ls -l]"), got)
+	}
+	if got := stdout.String(); strings.Count(got, "stdout\nstderr\n") != 2 {
+		t.Fatalf("command output count = %d, want 2; output %q", strings.Count(got, "stdout\nstderr\n"), got)
+	}
+}
+
+func TestNoTitle(t *testing.T) {
+	cmd := newCommand(
+		func(_ context.Context, _ []string, _ io.Reader, _, _ io.Writer) error { return nil },
+		func(_ context.Context, _ time.Duration) bool { return false },
+	)
+	var stdout bytes.Buffer
+	cmd.SetIO(strings.NewReader(""), &stdout, &bytes.Buffer{})
+
+	if err := cmd.RunContext(context.Background(), "-t", "ls"); err != nil {
+		t.Fatalf("RunContext() error = %v", err)
+	}
+
+	if got := stdout.String(); got != "\033[0;0H\033[J" {
+		t.Fatalf("output = %q, want only terminal clear sequence", got)
+	}
+}
+
+func TestNoCommandPrintsUsage(t *testing.T) {
+	called := false
+	cmd := newCommand(
+		func(_ context.Context, _ []string, _ io.Reader, _, _ io.Writer) error {
+			called = true
+			return nil
+		},
+		func(_ context.Context, _ time.Duration) bool { return false },
+	)
+	var stderr bytes.Buffer
+	cmd.SetIO(strings.NewReader(""), &bytes.Buffer{}, &stderr)
+
+	if err := cmd.RunContext(context.Background()); err != nil {
+		t.Fatalf("RunContext() error = %v", err)
+	}
+
+	if called {
+		t.Fatal("dispatcher was called without a command")
+	}
+	if got := stderr.String(); !strings.Contains(got, "Usage: watch") {
+		t.Fatalf("stderr = %q, want usage", got)
+	}
+}
+
+func TestCancellationStopsBeforeWaiting(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	waited := false
+	cmd := newCommand(
+		func(_ context.Context, _ []string, _ io.Reader, _, _ io.Writer) error {
+			calls++
+			cancel()
+			return context.Canceled
+		},
+		func(_ context.Context, _ time.Duration) bool {
+			waited = true
+			return true
+		},
+	)
+	cmd.SetIO(strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+
+	if err := cmd.RunContext(ctx, "ls"); err != nil {
+		t.Fatalf("RunContext() error = %v", err)
+	}
+
+	if calls != 1 {
+		t.Fatalf("dispatcher calls = %d, want 1", calls)
+	}
+	if waited {
+		t.Fatal("wait called after context cancellation")
+	}
+}
+
+func TestCtrlCStopsWatch(t *testing.T) {
+	stdin, input := io.Pipe()
+	defer stdin.Close()
+	defer input.Close()
+
+	executed := make(chan struct{})
+	cmd := newCommand(
+		func(_ context.Context, _ []string, _ io.Reader, _, _ io.Writer) error {
+			select {
+			case <-executed:
+			default:
+				close(executed)
+			}
+			return nil
+		},
+		waitForInterval,
+	)
+	cmd.SetIO(stdin, &bytes.Buffer{}, &bytes.Buffer{})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.RunContext(context.Background(), "-n", "60", "ls")
+	}()
+
+	select {
+	case <-executed:
+	case <-time.After(time.Second):
+		t.Fatal("watch did not execute its command")
+	}
+
+	if _, err := input.Write([]byte{'\x03', '\n'}); err != nil {
+		t.Fatalf("writing Ctrl-C: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RunContext() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("watch did not stop after Ctrl-C")
+	}
+}
+
+func TestCommandErrorsDoNotStopWatching(t *testing.T) {
+	calls := 0
+	waits := 0
+	cmd := newCommand(
+		func(_ context.Context, _ []string, _ io.Reader, _, _ io.Writer) error {
+			calls++
+			return errors.New("command failed")
+		},
+		func(_ context.Context, _ time.Duration) bool {
+			waits++
+			return waits == 1
+		},
+	)
+	cmd.SetIO(strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+
+	if err := cmd.RunContext(context.Background(), "false"); err != nil {
+		t.Fatalf("RunContext() error = %v", err)
+	}
+
+	if calls != 2 {
+		t.Fatalf("dispatcher calls = %d, want 2", calls)
+	}
+}
+
+func TestNonPositiveIntervalUsesDefault(t *testing.T) {
+	var got time.Duration
+	cmd := newCommand(
+		func(_ context.Context, _ []string, _ io.Reader, _, _ io.Writer) error { return nil },
+		func(_ context.Context, interval time.Duration) bool {
+			got = interval
+			return false
+		},
+	)
+	cmd.SetIO(strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+
+	if err := cmd.RunContext(context.Background(), "-n", "0", "ls"); err != nil {
+		t.Fatalf("RunContext() error = %v", err)
+	}
+
+	if want := 2 * time.Second; got != want {
+		t.Fatalf("interval = %v, want %v", got, want)
+	}
+}
+
+func TestDifferencesAreHighlighted(t *testing.T) {
+	outputs := []string{"value: 10\n", "value: 12\n"}
+	call := 0
+	wait := 0
+	cmd := newCommand(
+		func(_ context.Context, _ []string, _ io.Reader, stdout, _ io.Writer) error {
+			_, err := io.WriteString(stdout, outputs[call])
+			call++
+			return err
+		},
+		func(_ context.Context, _ time.Duration) bool {
+			wait++
+			return wait == 1
+		},
+	)
+	var stdout bytes.Buffer
+	cmd.SetIO(strings.NewReader(""), &stdout, &bytes.Buffer{})
+
+	if err := cmd.RunContext(context.Background(), "-d", "-n", "1", "counter"); err != nil {
+		t.Fatalf("RunContext() error = %v", err)
+	}
+
+	got := stdout.String()
+	if !strings.Contains(got, "value: 10\n") {
+		t.Fatalf("first output was unexpectedly highlighted or missing: %q", got)
+	}
+	if !strings.Contains(got, "value: 1\x1b[7m2\x1b[0m\n") {
+		t.Fatalf("second output does not highlight the changed character: %q", got)
+	}
+}
+
+func TestHighlightChanges(t *testing.T) {
+	tests := []struct {
+		name     string
+		previous string
+		current  string
+		want     string
+	}{
+		{name: "deleted characters", previous: "abc\n", current: "a\n", want: "a\x1b[7m  \x1b[0m\n"},
+		{name: "Unicode runes", previous: "café\n", current: "cafe\n", want: "caf\x1b[7me\x1b[0m\n"},
+		{name: "ANSI output", previous: "plain\n", current: "\x1b[32mgreen\x1b[0m\n", want: "\x1b[32mgreen\x1b[0m\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := highlightChanges(tt.previous, tt.current); got != tt.want {
+				t.Fatalf("highlightChanges() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -63,6 +63,24 @@ func TestExamplesHTML(t *testing.T) {
 	// For cleanup
 	defer srv.Shutdown(context.Background())
 
+	// This regression remains red until #243 is merged. watch's external
+	// child exits, but rc currently hangs before watch can regain stdin.
+	t.Run("rc watch external task stdio", func(t *testing.T) {
+		build := exec.Command("make", "-C", "examples/repl-rc", "build")
+		if out, err := build.CombinedOutput(); err != nil {
+			t.Fatalf("Error building rc example: %v\nOutput:\n%s", err, string(out))
+		}
+
+		url := fmt.Sprintf("%s/test/html/rc-watch-external-task.html", baseURL)
+		cmd := exec.Command("go", "run", ".", "-wait-load=false", "-wait-done", "-timeout=15s", url)
+		cmd.Dir = "./test/wtest"
+		cmd.Env = append(os.Environ(), "GOWORK=off")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("Error running rc watch external task test: %v\nOutput:\n%s", err, string(out))
+		}
+	})
+
 	htmlFiles := []string{}
 	err = filepath.Walk("./examples", func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -92,22 +110,4 @@ func TestExamplesHTML(t *testing.T) {
 			}
 		})
 	}
-
-	// This regression remains red until #243 is merged. watch's external
-	// child exits, but rc currently hangs before watch can regain stdin.
-	t.Run("rc watch external task stdio", func(t *testing.T) {
-		build := exec.Command("make", "-C", "examples/repl-rc", "build")
-		if out, err := build.CombinedOutput(); err != nil {
-			t.Fatalf("Error building rc example: %v\nOutput:\n%s", err, string(out))
-		}
-
-		url := fmt.Sprintf("%s/test/html/rc-watch-external-task.html", baseURL)
-		cmd := exec.Command("go", "run", ".", "-wait-load=false", "-wait-done", "-timeout=15s", url)
-		cmd.Dir = "./test/wtest"
-		cmd.Env = append(os.Environ(), "GOWORK=off")
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("Error running rc watch external task test: %v\nOutput:\n%s", err, string(out))
-		}
-	})
 }

--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -92,4 +92,22 @@ func TestExamplesHTML(t *testing.T) {
 			}
 		})
 	}
+
+	// This regression remains red until #243 is merged. watch's external
+	// child exits, but rc currently hangs before watch can regain stdin.
+	t.Run("rc watch external task stdio", func(t *testing.T) {
+		build := exec.Command("make", "-C", "examples/repl-rc", "build")
+		if out, err := build.CombinedOutput(); err != nil {
+			t.Fatalf("Error building rc example: %v\nOutput:\n%s", err, string(out))
+		}
+
+		url := fmt.Sprintf("%s/test/html/rc-watch-external-task.html", baseURL)
+		cmd := exec.Command("go", "run", ".", "-wait-load=false", "-wait-done", "-timeout=15s", url)
+		cmd.Dir = "./test/wtest"
+		cmd.Env = append(os.Environ(), "GOWORK=off")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("Error running rc watch external task test: %v\nOutput:\n%s", err, string(out))
+		}
+	})
 }

--- a/test/html/rc-watch-external-task.html
+++ b/test/html/rc-watch-external-task.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <title>rc watch external task stdio</title>
+    <script type="module" src="../../dist/wanix.min.js"></script>
+</head>
+<body>
+    <pre id="log"></pre>
+    <pre id="status"></pre>
+
+    <wanix-namespace wasm="../../dist/wanix.debug.wasm">
+        <wanix-bind dst="." src="#ramfs/new"></wanix-bind>
+        <wanix-bind type="file" dst="rc.wasm" src="../../examples/repl-rc/rc.wasm"></wanix-bind>
+        <wanix-task id="repl" cmd="rc.wasm" term></wanix-task>
+    </wanix-namespace>
+
+    <script type="module">
+        const logEl = document.getElementById("log");
+        const statusEl = document.getElementById("status");
+        const task = document.getElementById("repl");
+        const encoder = new TextEncoder();
+        const decoder = new TextDecoder();
+        let output = "";
+
+        function promptCount() {
+            return (output.match(/rc%/g) || []).length;
+        }
+
+        async function waitFor(description, predicate, timeout = 10000) {
+            const deadline = Date.now() + timeout;
+            while (Date.now() < deadline) {
+                if (predicate()) return;
+                await new Promise((resolve) => setTimeout(resolve, 25));
+            }
+            throw new Error(`timeout waiting for ${description}\noutput:\n${output}`);
+        }
+
+        async function taskIDs() {
+            return (await task.root.readDir("#task"))
+                .filter((name) => /^\d+\/$/.test(name))
+                .map((name) => name.slice(0, -1));
+        }
+
+        await task._nsReady;
+        await task.root.chmod("rc.wasm", 0o755);
+        await task.start();
+        const dataPath = `${task.term}/data`;
+        await task.root.waitFor(dataPath, 30000);
+        const reader = (await task.root.openReadable(dataPath)).getReader();
+        const writer = (await task.root.openWritable(dataPath)).getWriter();
+
+        (async () => {
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) return;
+                output += decoder.decode(value, {stream: true});
+                logEl.textContent = output;
+            }
+        })();
+
+        async function send(input) {
+            await writer.write(encoder.encode(input + "\n"));
+        }
+
+        await waitFor("initial prompt", () => promptCount() >= 1);
+
+        const beforeWatch = new Set(await taskIDs());
+        await send("watch -n 60 rc.wasm -c 'echo child'");
+        await waitFor("watched external command output", () => output.includes("child"));
+
+        await send("\x03");
+        await waitFor("parent prompt after interrupt", () => promptCount() >= 2);
+
+        await send("echo parent");
+        await waitFor("parent command", () => output.includes("parent") && promptCount() >= 3);
+
+        const childIDs = (await taskIDs()).filter((id) => !beforeWatch.has(id));
+        if (childIDs.length !== 1) {
+            throw new Error(`expected one watched child task, got ${childIDs.length}`);
+        }
+        const childID = childIDs[0];
+        const command = (await task.root.readText(`#task/${childID}/cmd`)).trim();
+        const exit = (await task.root.readText(`#task/${childID}/exit`)).trim();
+        if (command !== "rc.wasm -c 'echo child'" || exit !== "0") {
+            throw new Error(`task result: got ${command} -> ${exit}`);
+        }
+
+        statusEl.textContent =
+            `#task/${childID}: ${command} -> ${exit}\n` +
+            "watch interrupted; parent shell resumed\n" +
+            "ALL PASSED\n";
+        window.__wtest_done = true;
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- add and register an rc `watch` command with `-n`, `-t`, and `-d`
- dispatch watched programs through rc's existing command execution paths
- stop `watch` on terminal Ctrl-C without ending the rc session
- cover command execution, stream routing, differences, and interruption with tests

The implementation is adapted from u-root's experimental `watch`, but uses rc's
dispatcher instead of `os/exec`. `watch` owns terminal input while it is running;
each watched command receives EOF. Output is captured per iteration so the
terminal can be redrawn and `-d` can highlight changes. Commands outside `watch`
continue to use mvdan's original streams without buffering.

We can make this simpler without `-d` but personally it's my favourite part of watch, so adding it brought me joy. Open to any and all feedback.

## Known limitation

Browser/Wasm external commands currently inherit rc's existing task lifecycle
hang in #243. `watch` dispatches them through the normal path, but the first
iteration does not return, so external Wanix-task support is blocked until #243
is fixed. This PR does not change that task/terminal wiring. Bundled commands are
covered by the browser smoke test below.

Fixes #247.

## Test plan

- [x] `go vet ./...`
- [x] `go test -race ./...`
- [x] `GOOS=js GOARCH=wasm go test ./...` with Go's Wasm test runner
- [x] `node --check elements/term.js`
- [x] `make -C examples/repl-rc build`
- [x] browser smoke test: bundled command execution, ignored terminal input,
      Ctrl-C cancellation, and continued use of the same rc session
