### PR TITLE
rc: fix #243 - external task stdio lifecycle

### DIFF
--- a/rc/exec_wanix.go
+++ b/rc/exec_wanix.go
@@ -90,11 +90,11 @@ func runExternalCommand(ctx context.Context, hc interp.HandlerContext, path stri
 	if err != nil {
 		return 1, err
 	}
+	defer termOutput.Close()
 
 	if forwardStdin {
 		termInput, err := os.Open(filepath.Join(termPath, "data"))
 		if err != nil {
-			_ = termOutput.Close()
 			return 1, err
 		}
 		// todo: do we need to do line discpline?
@@ -113,7 +113,6 @@ func runExternalCommand(ctx context.Context, hc interp.HandlerContext, path stri
 	if err := AppendFile(filepath.Join(taskPath, "ctl"), []byte("start")); err != nil {
 		if closeErr := closeTerm(); closeErr == nil {
 			<-outputDone
-			_ = termOutput.Close()
 		}
 		return 1, err
 	}
@@ -122,7 +121,6 @@ func runExternalCommand(ctx context.Context, hc interp.HandlerContext, path stri
 	closeErr := closeTerm()
 	if closeErr == nil {
 		<-outputDone
-		_ = termOutput.Close()
 	}
 	if err != nil {
 		return 1, err

--- a/rc/exec_wanix.go
+++ b/rc/exec_wanix.go
@@ -25,11 +25,30 @@ func readString(path string) (string, error) {
 
 func runExternalCommand(ctx context.Context, hc interp.HandlerContext, path string, args []string) (int, error) {
 	argv := append([]string{path}, args...)
+	parentTaskID, err := readString("#task/self/id")
+	if err != nil {
+		return 1, err
+	}
+
 	termID, err := readString("#term/new")
 	if err != nil {
 		return 1, err
 	}
 	termPath := filepath.Join("#term", termID)
+	termClosed := false
+	closeTerm := func() error {
+		if termClosed {
+			return nil
+		}
+		if err := AppendFile(filepath.Join(termPath, "ctl"), []byte("close")); err != nil {
+			return err
+		}
+		termClosed = true
+		return nil
+	}
+	defer func() {
+		_ = closeTerm()
+	}()
 
 	// todo: need better auto so we dont have to use gojs here
 	taskID, err := readString("#task/new/gojs")
@@ -49,8 +68,15 @@ func runExternalCommand(ctx context.Context, hc interp.HandlerContext, path stri
 		return 1, err
 	}
 
+	forwardStdin := shouldForwardStdin(hc.Stdin)
+	// A foreground task inherits the shell's stdin. Copying it through a
+	// goroutine can leave a blocked reader competing with the resumed shell.
+	stdinPath := filepath.Join("#task", parentTaskID, "fd", "0")
+	if forwardStdin {
+		stdinPath = filepath.Join(termPath, "program")
+	}
 	ctlmsg := []string{
-		fmt.Sprintf("bind %s/program %s/fd/0", termPath, taskPath),
+		fmt.Sprintf("bind %s %s/fd/0", stdinPath, taskPath),
 		fmt.Sprintf("bind %s/program %s/fd/1", termPath, taskPath),
 		fmt.Sprintf("bind %s/program %s/fd/2", termPath, taskPath),
 	}
@@ -60,34 +86,49 @@ func runExternalCommand(ctx context.Context, hc interp.HandlerContext, path stri
 		}
 	}
 
-	termData, err := os.Open(filepath.Join(termPath, "data"))
+	termOutput, err := os.Open(filepath.Join(termPath, "data"))
 	if err != nil {
 		return 1, err
 	}
-	defer termData.Close()
 
-	if shouldForwardStdin(hc.Stdin) {
+	if forwardStdin {
+		termInput, err := os.Open(filepath.Join(termPath, "data"))
+		if err != nil {
+			_ = termOutput.Close()
+			return 1, err
+		}
 		// todo: do we need to do line discpline?
 		go func() {
-			println("copying stdin")
-			_, _ = io.Copy(termData, hc.Stdin)
-			println("stdin done")
+			defer termInput.Close()
+			_, _ = io.Copy(termInput, hc.Stdin)
 		}()
 	}
 
+	outputDone := make(chan struct{})
 	go func() {
-		println("copying stdout")
-		_, _ = io.Copy(hc.Stdout, termData)
-		println("stdout done")
+		defer close(outputDone)
+		_, _ = io.Copy(hc.Stdout, termOutput)
 	}()
 
 	if err := AppendFile(filepath.Join(taskPath, "ctl"), []byte("start")); err != nil {
+		if closeErr := closeTerm(); closeErr == nil {
+			<-outputDone
+			_ = termOutput.Close()
+		}
 		return 1, err
 	}
 
 	code, err := waitExitCode(ctx, filepath.Join(taskPath, "exit"))
+	closeErr := closeTerm()
+	if closeErr == nil {
+		<-outputDone
+		_ = termOutput.Close()
+	}
 	if err != nil {
 		return 1, err
+	}
+	if closeErr != nil {
+		return 1, closeErr
 	}
 
 	return code, nil

--- a/term/device.go
+++ b/term/device.go
@@ -5,11 +5,13 @@ import (
 	"strconv"
 	"sync"
 
+	"tractor.dev/toolkit-go/engine/cli"
 	"tractor.dev/wanix"
 	"tractor.dev/wanix/fs"
 	"tractor.dev/wanix/fs/fskit"
 	"tractor.dev/wanix/fs/pipe"
 	"tractor.dev/wanix/fs/signal"
+	"tractor.dev/wanix/misc"
 )
 
 type Device struct {
@@ -89,15 +91,28 @@ func (d *Device) Alloc() (rid string, err error) {
 	rid = strconv.Itoa(d.nextID)
 	hub := signal.NewBroadcaster()
 	_, dataPF, progPF := pipe.NewFS(true)
-	// remove := func() {
-	// 	d.remove(rid)
-	// }
-	progWrap := &programFile{PortFile: progPF}
+	remove := func() {
+		d.remove(rid)
+	}
+	progWrap := &programFile{
+		PortFile: progPF,
+		remove:   remove,
+	}
 	root := fskit.MapFS{
 		"id":      fskit.RawNode([]byte(rid+"\n"), 0555),
 		"data":    fskit.FileFS(dataPF, "data"),
 		"program": fskit.FileFS(progWrap, "program"),
 		"winch":   signal.NewFS(hub),
+		"ctl": misc.ControlFile(&cli.Command{
+			Usage: "ctl",
+			Short: "control the terminal",
+			Run: func(_ *cli.Context, args []string) {
+				switch args[0] {
+				case "close":
+					remove()
+				}
+			},
+		}),
 	}
 	d.resources[rid] = &Resource{
 		id:    rid,
@@ -110,12 +125,13 @@ func (d *Device) Alloc() (rid string, err error) {
 
 func (d *Device) remove(rid string) {
 	d.mu.Lock()
-	res, err := d.Get(rid)
-	if err != nil {
-		d.mu.Unlock()
-		return
+	fsys, ok := d.resources[rid]
+	if ok {
+		delete(d.resources, rid)
 	}
-	delete(d.resources, rid)
 	d.mu.Unlock()
-	res.shutdown()
+
+	if ok {
+		fsys.(*Resource).shutdown()
+	}
 }

--- a/term/resource.go
+++ b/term/resource.go
@@ -1,6 +1,8 @@
 package term
 
 import (
+	"io"
+
 	"tractor.dev/wanix/fs/fskit"
 	"tractor.dev/wanix/fs/pipe"
 	"tractor.dev/wanix/fs/signal"
@@ -28,7 +30,16 @@ func (r *Resource) shutdown() {
 
 type programFile struct {
 	*pipe.PortFile
-	prev byte // last input byte seen, for cross-call lookbehind
+	prev   byte // last input byte seen, for cross-call lookbehind
+	remove func()
+}
+
+func (c *programFile) Read(p []byte) (int, error) {
+	n, err := c.PortFile.Read(p)
+	if err == io.EOF {
+		c.remove()
+	}
+	return n, err
 }
 
 func (c *programFile) Write(p []byte) (int, error) {

--- a/term/term_test.go
+++ b/term/term_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"runtime"
 	"testing"
+	"time"
 
 	"tractor.dev/wanix/fs"
 )
@@ -103,6 +104,54 @@ func TestProgramEOFRemoves(t *testing.T) {
 	s.mu.RUnlock()
 	if ok {
 		t.Fatal("resource should be removed after program EOF")
+	}
+}
+
+func TestCloseUnblocksDataReaderAndRemoves(t *testing.T) {
+	ctx := context.Background()
+	s := New(nil)
+	newf, err := fs.OpenContext(ctx, s, "new")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newf.Read(make([]byte, 8)); err != nil {
+		t.Fatal(err)
+	}
+	newf.Close()
+
+	data, err := fs.OpenContext(ctx, s, "1/data")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer data.Close()
+
+	readErr := make(chan error, 1)
+	go func() {
+		_, err := data.Read(make([]byte, 8))
+		readErr <- err
+	}()
+
+	ctl, err := fs.OpenContext(ctx, s, "1/ctl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ctl.(io.Writer).Write([]byte("close")); err != nil {
+		t.Fatal(err)
+	}
+	if err := ctl.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case err := <-readErr:
+		if err != io.EOF {
+			t.Fatalf("Read: got %v, want EOF", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("data reader remained blocked after close")
+	}
+	if _, err := s.Get("1"); err != fs.ErrNotExist {
+		t.Fatalf("Get: got %v, want %v", err, fs.ErrNotExist)
 	}
 }
 

--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -92,4 +92,20 @@ func TestExamplesHTML(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("rc external task stdio", func(t *testing.T) {
+		build := exec.Command("make", "-C", "examples/repl-rc", "build")
+		if out, err := build.CombinedOutput(); err != nil {
+			t.Fatalf("Error building rc example: %v\nOutput:\n%s", err, string(out))
+		}
+
+		url := fmt.Sprintf("%s/test/html/rc-external-task.html", baseURL)
+		cmd := exec.Command("go", "run", ".", "-wait-load=false", "-wait-done", "-timeout=45s", url)
+		cmd.Dir = "./test/wtest"
+		cmd.Env = append(os.Environ(), "GOWORK=off")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("Error running rc external task test: %v\nOutput:\n%s", err, string(out))
+		}
+	})
 }

--- a/test/html/rc-external-task.html
+++ b/test/html/rc-external-task.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <title>rc external task stdio</title>
+    <script type="module" src="../../dist/wanix.min.js"></script>
+</head>
+<body>
+    <pre id="log"></pre>
+    <pre id="status"></pre>
+
+    <wanix-namespace wasm="../../dist/wanix.debug.wasm">
+        <wanix-bind dst="." src="#ramfs/new"></wanix-bind>
+        <wanix-bind type="file" dst="rc.wasm" src="../../examples/repl-rc/rc.wasm"></wanix-bind>
+        <wanix-task id="repl" cmd="rc.wasm" term></wanix-task>
+    </wanix-namespace>
+
+    <script type="module">
+        const logEl = document.getElementById("log");
+        const statusEl = document.getElementById("status");
+        const task = document.getElementById("repl");
+        const encoder = new TextEncoder();
+        const decoder = new TextDecoder();
+        let output = "";
+
+        function promptCount() {
+            return (output.match(/rc%/g) || []).length;
+        }
+
+        async function waitFor(description, predicate, timeout = 10000) {
+            const deadline = Date.now() + timeout;
+            while (Date.now() < deadline) {
+                if (predicate()) return;
+                await new Promise((resolve) => setTimeout(resolve, 25));
+            }
+            throw new Error(`timeout waiting for ${description}\noutput:\n${output}`);
+        }
+
+        async function taskIDs() {
+            return (await task.root.readDir("#task"))
+                .filter((name) => /^\d+\/$/.test(name))
+                .map((name) => name.slice(0, -1));
+        }
+
+        function newTaskID(before, after) {
+            const added = after.filter((id) => !before.has(id));
+            if (added.length !== 1) {
+                throw new Error(`expected one new task, got ${added.length}`);
+            }
+            return added[0];
+        }
+
+        async function taskResult(id) {
+            return {
+                cmd: (await task.root.readText(`#task/${id}/cmd`)).trim(),
+                exit: (await task.root.readText(`#task/${id}/exit`)).trim(),
+            };
+        }
+
+        function assertTaskResult(result, cmd) {
+            if (result.cmd !== cmd || result.exit !== "0") {
+                throw new Error(
+                    `task result: got ${result.cmd} -> ${result.exit}, want ${cmd} -> 0`);
+            }
+        }
+
+        await task._nsReady;
+        await task.root.chmod("rc.wasm", 0o755);
+        await task.start();
+        const dataPath = `${task.term}/data`;
+        await task.root.waitFor(dataPath, 30000);
+        const reader = (await task.root.openReadable(dataPath)).getReader();
+        const writer = (await task.root.openWritable(dataPath)).getWriter();
+
+        (async () => {
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) return;
+                output += decoder.decode(value, {stream: true});
+                logEl.textContent = output;
+            }
+        })();
+
+        async function send(command) {
+            await writer.write(encoder.encode(command + "\n"));
+        }
+
+        await waitFor("initial prompt", () => promptCount() >= 1);
+
+        const beforeCommand = new Set(await taskIDs());
+        await send("rc.wasm -c 'echo child'");
+        await waitFor("child output and parent prompt",
+            () => output.includes("child") && promptCount() >= 2);
+        const commandTaskID = newTaskID(beforeCommand, await taskIDs());
+        const commandResult = await taskResult(commandTaskID);
+        assertTaskResult(commandResult, "rc.wasm -c 'echo child'");
+
+        const beforeNested = new Set(await taskIDs());
+        await send("rc.wasm");
+        await waitFor("nested prompt", () => promptCount() >= 3);
+
+        await send("echo nested");
+        await waitFor("nested command", () => output.includes("nested") && promptCount() >= 4);
+
+        await send("exit");
+        await waitFor("parent prompt after nested exit", () => promptCount() >= 5);
+        const nestedTaskID = newTaskID(beforeNested, await taskIDs());
+        const nestedResult = await taskResult(nestedTaskID);
+        assertTaskResult(nestedResult, "rc.wasm");
+
+        await send("echo parent");
+        await waitFor("parent command", () => output.includes("parent") && promptCount() >= 6);
+
+        statusEl.textContent =
+            `#task/${commandTaskID}: ${commandResult.cmd} -> ${commandResult.exit}\n` +
+            `#task/${nestedTaskID}: ${nestedResult.cmd} -> ${nestedResult.exit}\n` +
+            "ALL PASSED\n";
+        window.__wtest_done = true;
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Fixes #243.

External commands launched by `rc` could finish without returning control to the parent shell. Two lifecycle problems were involved:

- foreground children copied stdin through a goroutine, leaving a blocked reader competing with the resumed shell;
- the temporary terminal remained open after the child exited, so the output-copy goroutine never observed EOF.

This binds foreground child stdin directly to the parent task's fd 0, adds an explicit terminal `close` control, and waits for remaining output before returning to the prompt. Scoped readers used by commands such as `watch` continue to be forwarded through the temporary terminal.

The browser regression covers both command mode and an interactive nested `rc`, verifies the child task records and exit statuses, and confirms the parent shell resumes.

Super open to any and all feedback. 🙏 