### PR TITLE
p9kit: paginate directory reads

### DIFF
--- a/fs/p9kit/client.go
+++ b/fs/p9kit/client.go
@@ -2,6 +2,7 @@ package p9kit
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -363,7 +364,7 @@ func (fsys *FS) ReadDir(name string) ([]fs.DirEntry, error) {
 		return nil, translateError("readdir", name, err)
 	}
 
-	dirents, err := f.Readdir(0, 65535) // max uint32 breaks p9kit server
+	dirents, err := readDirents(f)
 	if err != nil {
 		return nil, translateError("readdir", name, err)
 	}
@@ -382,6 +383,33 @@ func (fsys *FS) ReadDir(name string) ([]fs.DirEntry, error) {
 		})
 	}
 	return entries, nil
+}
+
+const readdirCount = 65535 // max uint32 breaks p9kit server
+
+func readDirents(dir p9.File) (p9.Dirents, error) {
+	var (
+		dirents p9.Dirents
+		offset  uint64
+	)
+	for {
+		entries, err := dir.Readdir(offset, readdirCount)
+		if err != nil {
+			return nil, err
+		}
+		if len(entries) == 0 {
+			return dirents, nil
+		}
+
+		// A short non-empty 9P directory read is not EOF: the next
+		// complete dirent may simply not have fit in the response.
+		dirents = append(dirents, entries...)
+		next := entries[len(entries)-1].Offset
+		if next == offset {
+			return nil, fmt.Errorf("readdir made no progress at offset %d", offset)
+		}
+		offset = next
+	}
 }
 
 // lazyEntry is a directory entry built from a 9P dirent: the name and
@@ -486,7 +514,7 @@ func (f *remoteFile) Stat() (fs.FileInfo, error) {
 func (f *remoteFile) ReadDir(n int) ([]fs.DirEntry, error) {
 	if f.iter == nil {
 		f.iter = fskit.NewDirIter(func() ([]fs.DirEntry, error) {
-			dirents, err := f.file.Readdir(0, 65535) // max uint32 breaks p9kit server
+			dirents, err := readDirents(f.file)
 			if err != nil {
 				return nil, translateError("readdir", f.name, err)
 			}

--- a/fs/p9kit/p9kit_test.go
+++ b/fs/p9kit/p9kit_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -107,6 +108,72 @@ func TestIntegration_BasicReadWrite(t *testing.T) {
 			t.Errorf("ReadDir: expected foo3, got %s", entries[0].Name())
 		}
 	})
+}
+
+func TestIntegration_LargeDirectory(t *testing.T) {
+	tests := []struct {
+		name    string
+		count   int
+		padding int
+	}{
+		{name: "original count beyond one message", count: 408, padding: 160},
+		{name: "high entry count", count: 4096},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes := make(fskit.MapFS, tt.count)
+			names := make(map[string]struct{}, tt.count)
+			padding := strings.Repeat("x", tt.padding)
+			for i := 0; i < tt.count; i++ {
+				name := fmt.Sprintf("command-%05d-%s", i, padding)
+				nodes[name] = fskit.RawNode([]byte("#!/bin/sh\n"))
+				names[name] = struct{}{}
+			}
+
+			fsys, cleanup := testSetup(t, memfs.From(nodes))
+			defer cleanup()
+
+			checkEntries := func(t *testing.T, entries []fs.DirEntry, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("ReadDir: %v", err)
+				}
+				if len(entries) != tt.count {
+					t.Fatalf("got %d entries, want %d", len(entries), tt.count)
+				}
+				seen := make(map[string]bool, len(entries))
+				for _, entry := range entries {
+					if _, ok := names[entry.Name()]; !ok {
+						t.Fatalf("unexpected entry %q", entry.Name())
+					}
+					if seen[entry.Name()] {
+						t.Fatalf("duplicate entry %q", entry.Name())
+					}
+					seen[entry.Name()] = true
+				}
+			}
+
+			t.Run("FS.ReadDir", func(t *testing.T) {
+				entries, err := fs.ReadDir(fsys, ".")
+				checkEntries(t, entries, err)
+			})
+
+			t.Run("File.ReadDir", func(t *testing.T) {
+				f, err := fsys.Open(".")
+				if err != nil {
+					t.Fatalf("Open: %v", err)
+				}
+				defer f.Close()
+				rdf, ok := f.(fs.ReadDirFile)
+				if !ok {
+					t.Fatalf("not a ReadDirFile: %T", f)
+				}
+				entries, err := rdf.ReadDir(-1)
+				checkEntries(t, entries, err)
+			})
+		})
+	}
 }
 
 func TestIntegration_CreateAndWrite(t *testing.T) {

--- a/fs/p9kit/wirecost_test.go
+++ b/fs/p9kit/wirecost_test.go
@@ -97,14 +97,15 @@ func expectCounts(t *testing.T, phase string, got map[uint8]int, want map[uint8]
 // regression toward per-entry round-trips fails loudly:
 //
 //   - FS.ReadDir builds entries from the dirents it already holds:
-//     one walk+open+list+clunk regardless of entry count, attributes
-//     fetched only if Info() is called.
+//     one walk+open, as many reads as the listing needs plus one for
+//     EOF, and one clunk; attributes are fetched only if Info() is
+//     called.
 //   - OpenContext types the target by its walk qid: directories open
 //     ReadOnly directly instead of failing a ReadWrite attempt first.
 //   - remoteFile.ReadDir types entries by their own dirent qids.
 //   - Close fsyncs only handles that were opened writable.
 //
-// Composite effect: one ls-shaped pass over 7 entries costs 28
+// Composite effect: one ls-shaped pass over 7 entries costs 29
 // messages (down from 51 with per-entry stats), and the remaining
 // floor is the caller's own per-entry Stat, not ReadDir overhead.
 func TestLsWireCostBaseline(t *testing.T) {
@@ -133,7 +134,7 @@ func TestLsWireCostBaseline(t *testing.T) {
 			msgTgetattr: 0,
 			msgTclunk:   1,
 			msgTlopen:   1,
-			msgTreaddir: 1,
+			msgTreaddir: 2, // entries, then empty reply confirming EOF
 		})
 	})
 
@@ -158,7 +159,7 @@ func TestLsWireCostBaseline(t *testing.T) {
 			t.Fatalf("remoteFile.ReadDir: %v", err)
 		}
 		expectCounts(t, "remoteFile.ReadDir", cc.take(), map[uint8]int{
-			msgTreaddir: 1,
+			msgTreaddir: 2, // entries, then empty reply confirming EOF
 			msgTgetattr: 0, // entry types come from the dirent qids
 			msgTwalk:    0,
 		})
@@ -195,15 +196,16 @@ func TestLsWireCostBaseline(t *testing.T) {
 		for _, n := range got {
 			total += n
 		}
-		// Seven entries cost 28 messages per listing pass: Stat(dir)=3 +
-		// ReadDir=4 (walk+open+list+clunk) + 7×Stat(entry)=21. The
+		// Seven entries cost 29 messages per listing pass: Stat(dir)=3 +
+		// ReadDir=5 (walk+open+list+EOF+clunk) + 7×Stat(entry)=21. The
 		// per-entry Stats are the caller's own (filepath.Walk lstats
 		// everything); ReadDir itself adds no per-entry traffic.
-		if total != 28 {
-			t.Errorf("composite ls total = %d messages, want 28 (was 51 before the listing fixes)", total)
+		if total != 29 {
+			t.Errorf("composite ls total = %d messages, want 29 (was 51 before the listing fixes)", total)
 		}
 		expectCounts(t, "composite", got, map[uint8]int{
 			msgTgetattr: 8, // dir + 7 in per-entry Stat; none from ReadDir
+			msgTreaddir: 2, // entries, then empty reply confirming EOF
 			msgTwalk:    9,
 			msgTclunk:   9,
 		})


### PR DESCRIPTION
## Context

#256 has merged; this PR now directly targets `main`.

## Summary

- continue 9P directory reads using each page's final offset
- apply the same pagination to `FS.ReadDir` and opened-directory `ReadDir`
- cover payload-heavy and high-entry-count directories without omissions or duplicates
- update #256's wire-cost baseline for the required EOF probe

## Root cause

`Treaddir` limits response bytes, not directory entries. The client issued one
request and treated any short response as EOF, but a short non-empty response
can mean the next complete dirent did not fit. Large listings were therefore
silently truncated.

The client now reads until the server returns an empty page. An empty directory
still costs one `Treaddir`; a non-empty listing costs its data pages plus one
request confirming EOF.

## Reproduction

- 408 long filenames returned 330 entries before the fix
- 4,096 ordinary filenames returned 1,724 entries before the fix

## Validation

- `go test -count=10 ./fs/p9kit`
- `go vet ./fs/p9kit`
- `go test -race -count=5 -run '^TestIntegration_LargeDirectory$' ./fs/p9kit`
- browser regression: `rc ls` returned all 408 generated long-named files

Fixes #175.
